### PR TITLE
Add to the list php-openapi to the list of test suite users

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Also used as test suite in the following projects:
  - [ardoq-swagger-addon](https://github.com/ardoq/ardoq-swagger-addon) - Ardoq OpenAPI addon
  - [swagvali](https://github.com/subeeshcbabu/swagvali/) - Module to build validators for OpenAPI Request parameters and Response objects
  - [swagger-search](https://github.com/IG-Group/swagger-search) - An application that collects and indexes swagger docs from your microservices architecture
+ - [php-openapi](https://github.com/cebe/php-openapi) - PHP OpenAPI library for reading and writing
 
 
 Integration with 3rd-party services


### PR DESCRIPTION
See the tests in https://github.com/cebe/php-openapi/blob/893ab104be1f5dfe5a39766703f583584e43c6e1/tests/spec/OpenApiTest.php
+ composer.json for how this is being used as a way to check the library works for a lot of different spec files.

Want to add this to the list since this has been a robust library that others in the PHP community have been able to build on, and having this as a dataset helps maintain this + might help inspire other libraries in other languages to pull this in for testing.

Thank you.