### PR TITLE
Add cybersecurity-japan.com Website Security Snapshot API

### DIFF
--- a/APIs/cybersecurity-japan.com/1.0.0/openapi.yaml
+++ b/APIs/cybersecurity-japan.com/1.0.0/openapi.yaml
@@ -1,0 +1,53 @@
+openapi: 3.1.0
+info:
+  title: Website Security Snapshot API
+  version: 1.0.0
+  description: >-
+    One URL in, machine-readable security hygiene out.
+    Checks HSTS, CSP, X-Frame-Options, X-Content-Type-Options,
+    Referrer-Policy, Permissions-Policy and more.
+    Paid via x402 protocol (0.05 USDC / call on Base). No account required.
+  contact:
+    email: support@cybersecurity-japan.com
+  x-apisguru-categories:
+    - security
+  x-logo:
+    url: https://api.cybersecurity-japan.com/favicon.ico
+servers:
+  - url: https://api.cybersecurity-japan.com
+paths:
+  /v1/snapshot:
+    post:
+      summary: Run a security snapshot on a URL
+      description: Requires x402 payment of 0.05 USDC on Base.
+      operationId: postSnapshot
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [url]
+              properties:
+                url:
+                  type: string
+                  example: https://example.com
+      responses:
+        "200":
+          description: Snapshot result
+        "402":
+          description: Payment required (x402 challenge)
+  /demo/snapshot:
+    get:
+      summary: Canned demo snapshot (no payment required)
+      operationId: getDemoSnapshot
+      responses:
+        "200":
+          description: Pre-baked example snapshot
+  /health:
+    get:
+      summary: Health check
+      operationId: getHealth
+      responses:
+        "200":
+          description: OK


### PR DESCRIPTION
## New API submission

**API name:** Website Security Snapshot API
**Base URL:** https://api.cybersecurity-japan.com
**OpenAPI spec:** https://api.cybersecurity-japan.com/openapi.json

### Description

A pay-per-call API that scans any public URL's HTTP security headers and returns machine-readable JSON. Uses the x402 protocol (HTTP 402 Payment Required) — 0.05 USDC per call on Base. No account or API key required.

**Checks performed:**
- HSTS, CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy
- HTTPS enforcement and redirect chain depth
- Presence of security.txt, robots.txt, sitemap.xml

### Endpoints
- `GET /demo/snapshot` — Free canned response (no payment)
- `POST /v1/snapshot` — Live paid scan
- `GET /health` — Service status
- `GET /openapi.json` — Full OpenAPI 3.1 spec