### PR TITLE
Add latest xkcd comic details fetched from API

### DIFF
--- a/xkcd-latest-comic.json
+++ b/xkcd-latest-comic.json
@@ -1,0 +1,13 @@
+{
+  "month": "4",
+  "num": 3231,
+  "link": "",
+  "year": "2026",
+  "news": "",
+  "safe_title": "Lightning",
+  "transcript": "",
+  "alt": "Maybe you should wear one too? I guess I'm taller than you, so as long as I have one we're fine.",
+  "img": "https://imgs.xkcd.com/comics/lightning.png",
+  "title": "Lightning",
+  "day": "10"
+}


### PR DESCRIPTION
## Summary
- Fetched and presented the latest xkcd comic details successfully from the xkcd API.
- Called `GET https://xkcd.com/info.0.json` and saved the response as `xkcd-latest-comic.json`.
- Comic retrieved: **#3231 – "Lightning"** (published 2026-04-10).

## Test plan
- [ ] Verify `xkcd-latest-comic.json` contains valid JSON matching the xkcd API schema.
- [ ] Confirm `num`, `title`, `img`, and `alt` fields are present and non-empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)