### PR TITLE
Add skynetx.io 1.0.0 — crypto derivatives & market data API

### DIFF
--- a/APIs/skynetx.io/1.0.0/openapi.json
+++ b/APIs/skynetx.io/1.0.0/openapi.json
@@ -1,0 +1,13093 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "SkynetX Market Data API",
+    "version": "1.0.0",
+    "description": "Crypto-derivatives, on-chain, ETF, options, and macro data for autonomous agents and quant systems. Every endpoint returns the same envelope: `{ data, meta?, error? }`. Bearer auth with `cg_live_*` keys; anonymous tier available for public series (fear & greed, status, symbols).",
+    "termsOfService": "https://skynetx.io/legal/terms",
+    "contact": {
+      "name": "SkynetX Support",
+      "email": "support@skynetx.io",
+      "url": "https://skynetx.io/docs/api"
+    },
+    "license": {
+      "name": "Proprietary",
+      "url": "https://skynetx.io/legal/terms"
+    },
+    "x-logo": {
+      "url": "https://skynetx.io/icon.png",
+      "altText": "SkynetX"
+    },
+    "x-llm-discovery": {
+      "llmsTxt": "https://skynetx.io/llms.txt",
+      "llmsFullTxt": "https://skynetx.io/llms-full.txt",
+      "docsHuman": "https://skynetx.io/docs/api"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://skynetx.io",
+      "description": "Production"
+    },
+    {
+      "url": "http://localhost:3000",
+      "description": "Local dev"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Futures",
+      "description": "Derivatives data across all major CEXs — liquidations, open interest, funding, long/short ratios."
+    },
+    {
+      "name": "Spot",
+      "description": "Spot-market quote and directory endpoints — the symbol table is shared across asset classes."
+    },
+    {
+      "name": "Coins",
+      "description": "Per-asset rollups — aggregated price, OI, funding, and volume stats across every venue for a single base."
+    },
+    {
+      "name": "Markets",
+      "description": "Market-wide overviews — totals, gainers, losers, most-traded; the macro-lens over the coin universe."
+    },
+    {
+      "name": "Exchanges",
+      "description": "Venue directory and per-exchange rollups — OI, volume, instrument coverage, heartbeat status."
+    },
+    {
+      "name": "Options",
+      "description": "Deribit options chain, Greeks, put/call ratio, max-pain by underlying."
+    },
+    {
+      "name": "On-chain",
+      "description": "Network-level metrics sourced from CoinMetrics — realized cap, active addresses, NVT, and more."
+    },
+    {
+      "name": "ETFs",
+      "description": "Spot Bitcoin and Ethereum ETF flows, AUM, issuer breakdowns."
+    },
+    {
+      "name": "Sentiment",
+      "description": "Market-wide psychology indices. Start with fear & greed; more to come."
+    },
+    {
+      "name": "Indicators",
+      "description": "Derived cycle-signal dashboards — bull-market-peak, Pi Cycle, MVRV Z-Score, Rainbow band, and more. Computed from free on-chain primitives."
+    },
+    {
+      "name": "Macro",
+      "description": "Traditional-finance macro series (M2, DXY, gold) from FRED. Powers the 'crypto vs. global liquidity' overlays. Requires the FRED ingestion adapter to be live."
+    },
+    {
+      "name": "Hyperliquid",
+      "description": "Hyperliquid-specific data — HLP vault, trader leaderboards, whale positions, predicted funding."
+    },
+    {
+      "name": "DEX",
+      "description": "Cross-venue DEX comparison plus per-venue drill-downs — dYdX v4, GMX v2 (multi-chain), Drift + insurance fund, Paradex, Vertex."
+    },
+    {
+      "name": "Meta",
+      "description": "Directory and operational endpoints. Use `symbols` on startup, `status` for monitoring."
+    }
+  ],
+  "paths": {
+    "/api/v1/liquidations": {
+      "get": {
+        "summary": "Recent forced-close events across every derivatives exchange we ingest.",
+        "description": "Use this when you need a raw feed of long or short liquidations — the textbook contrarian / squeeze signal. Results are newest-first. Filter by `coin` to isolate a single asset, or by `source` to compare venues (Binance vs Bybit vs OKX). When neither filter is supplied this is identical to the table on `/liquidations`.",
+        "operationId": "liquidations",
+        "tags": [
+          "Futures"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Rows to return. Max 1000.",
+            "schema": {
+              "type": "number",
+              "default": 100
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Pagination offset. Combine with `limit` for stable paging.",
+            "schema": {
+              "type": "number",
+              "default": 0
+            }
+          },
+          {
+            "name": "coin",
+            "in": "query",
+            "required": false,
+            "description": "Base asset (e.g. `BTC`, `ETH`). Case-insensitive, uppercase on the wire.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "description": "Exchange key — e.g. `binance_futures`, `bybit`, `htx_linear_swap`. Call `/api/v1/status` to see which adapters are active.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": [
+                    {
+                      "ts": 1744835210123,
+                      "canonicalSymbol": "BTCUSDT",
+                      "side": "long",
+                      "price": 63180.5,
+                      "qtyUsd": 485231.22,
+                      "source": "binance_futures"
+                    },
+                    {
+                      "ts": 1744835204411,
+                      "canonicalSymbol": "BTCUSDT",
+                      "side": "short",
+                      "price": 63205,
+                      "qtyUsd": 91220,
+                      "source": "bybit"
+                    }
+                  ],
+                  "meta": {
+                    "total": 2,
+                    "limit": 5,
+                    "offset": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/open-interest": {
+      "get": {
+        "summary": "Cross-exchange open interest — totals, top coins, or per-coin time series.",
+        "description": "Open interest tells you how much capital is sitting in derivatives positions right now. Without a `coin`, this returns the aggregate dashboard view (totals + top 20). With a `coin`, you get a bucketed time series across every source, plus a per-source breakdown so you can chart Binance vs Bybit OI side-by-side. Buckets are 5-minute aggregates to match the on-page chart.",
+        "operationId": "openInterest",
+        "tags": [
+          "Futures"
+        ],
+        "parameters": [
+          {
+            "name": "coin",
+            "in": "query",
+            "required": false,
+            "description": "Base asset. When supplied, you get history + per-source split. When omitted, aggregate totals + top 20.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "description": "Only honoured when `coin` is supplied. Narrows the per-source breakdown to a single exchange.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "window",
+            "in": "query",
+            "required": false,
+            "description": "Trailing lookback window.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1h",
+                "24h",
+                "7d"
+              ],
+              "default": "24h"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "base": "BTC",
+                    "window": {
+                      "label": "24h",
+                      "hours": 24
+                    },
+                    "history": [
+                      {
+                        "ts": 1744820400000,
+                        "oiUsd": 28453120000
+                      },
+                      {
+                        "ts": 1744820700000,
+                        "oiUsd": 28511002100
+                      }
+                    ],
+                    "perSource": {
+                      "binance_futures": [
+                        {
+                          "ts": 1744820400000,
+                          "oiUsd": 12410200000
+                        }
+                      ],
+                      "bybit": [
+                        {
+                          "ts": 1744820400000,
+                          "oiUsd": 8210100000
+                        }
+                      ]
+                    }
+                  },
+                  "meta": {
+                    "total": 2,
+                    "window": "24h"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "startup",
+        "x-rate-limit-rpm": 80
+      }
+    },
+    "/api/v1/funding-rates": {
+      "get": {
+        "summary": "Current funding matrix across every exchange, or per-coin history for carry-strategy backtests.",
+        "description": "Funding rates are what perpetual swap longs pay shorts (or vice versa) to keep price pinned to spot. Without `coin`, you get a pivot table (coin × exchange) of the latest rates plus the current extremes — useful for spotting cross-venue funding arb. With a `coin`, you get a daily time series for that single asset, good for backtesting funding-carry strategies.",
+        "operationId": "fundingRates",
+        "tags": [
+          "Futures"
+        ],
+        "parameters": [
+          {
+            "name": "coin",
+            "in": "query",
+            "required": false,
+            "description": "Switch to time-series mode for a single base asset.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Only honoured when `coin` is supplied. Trailing window. Max 90.",
+            "schema": {
+              "type": "number",
+              "default": 7
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "base": "ETH",
+                    "days": 7,
+                    "points": [
+                      {
+                        "ts": 1744220400000,
+                        "rate": 0.0001,
+                        "apr": 10.95
+                      },
+                      {
+                        "ts": 1744249200000,
+                        "rate": 0.00008,
+                        "apr": 8.76
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 2,
+                    "days": 7
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "startup",
+        "x-rate-limit-rpm": 80
+      }
+    },
+    "/api/v1/long-short": {
+      "get": {
+        "summary": "Aggregate and elite-trader long/short positioning ratios — the classic contrarian feed.",
+        "description": "Retail long/short ratios tell you where the crowd is positioned; top-trader ratios tell you where the smart money sits. When they diverge, that's tradeable information. The `type` parameter picks which ratio flavour you want. Pass a `coin` and you also get that coin's history so you can chart the ratio over time.",
+        "operationId": "longShort",
+        "tags": [
+          "Futures"
+        ],
+        "parameters": [
+          {
+            "name": "type",
+            "in": "query",
+            "required": true,
+            "description": "Which ratio bucket to query.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "global_account",
+                "top_trader_position",
+                "top_trader_account",
+                "elite_position",
+                "taker_volume"
+              ]
+            }
+          },
+          {
+            "name": "coin",
+            "in": "query",
+            "required": false,
+            "description": "When supplied, the `history` array is populated for this base asset.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "hours",
+            "in": "query",
+            "required": false,
+            "description": "History window in hours. Max 720 (30 days).",
+            "schema": {
+              "type": "number",
+              "default": 24
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Cap on the `latest` rows. Max 200.",
+            "schema": {
+              "type": "number",
+              "default": 50
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "type": "top_trader_position",
+                    "summary": {
+                      "avgRatio": 1.12,
+                      "bullish": 34,
+                      "bearish": 16
+                    },
+                    "latest": [
+                      {
+                        "coin": "BTC",
+                        "ratio": 1.27,
+                        "longPct": 55.9,
+                        "shortPct": 44.1,
+                        "ts": 1744835000000
+                      },
+                      {
+                        "coin": "ETH",
+                        "ratio": 0.92,
+                        "longPct": 47.9,
+                        "shortPct": 52.1,
+                        "ts": 1744835000000
+                      }
+                    ],
+                    "history": [
+                      {
+                        "ts": 1744748600000,
+                        "ratio": 1.18,
+                        "longPct": 54.1,
+                        "shortPct": 45.9
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 2,
+                    "limit": 50,
+                    "historyPoints": 1
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "startup",
+        "x-rate-limit-rpm": 80
+      }
+    },
+    "/api/v1/futures/funding/history": {
+      "get": {
+        "summary": "Per-coin funding rate history in 8-hour buckets, cross-exchange average.",
+        "description": "Time series funding for a single base asset, averaged across every exchange that reports it. Same bucketing + cadence as the on-page funding history chart — use for carry-strategy backtests or for rendering a single-coin history line alongside the matrix.",
+        "operationId": "futuresFundingHistory",
+        "tags": [
+          "Futures"
+        ],
+        "parameters": [
+          {
+            "name": "coin",
+            "in": "query",
+            "required": true,
+            "description": "Base asset (BTC, ETH, …).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Trailing window. Max 90.",
+            "schema": {
+              "type": "number",
+              "default": 7
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "base": "BTC",
+                    "days": 7,
+                    "points": [
+                      {
+                        "ts": 1744220400000,
+                        "avgRate": 0.00011,
+                        "sampleCount": 5
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1,
+                    "days": 7
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "startup",
+        "x-rate-limit-rpm": 80
+      }
+    },
+    "/api/v1/futures/funding/heatmap": {
+      "get": {
+        "summary": "Cross-exchange funding matrix (coins × exchanges) + current extremes.",
+        "description": "Identical payload to the matrix arm of `/api/v1/funding-rates` — exposed here under the futures namespace so clients that group by product can find it. Ideal for spotting cross-venue funding divergence in one round trip.",
+        "operationId": "futuresFundingHeatmap",
+        "tags": [
+          "Futures"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "coins": [
+                      "BTC",
+                      "ETH"
+                    ],
+                    "exchanges": [
+                      "binance_futures",
+                      "bybit",
+                      "okx",
+                      "htx_linear_swap",
+                      "hyperliquid"
+                    ],
+                    "matrix": {
+                      "BTC": {
+                        "binance_futures": {
+                          "rate": 0.0001,
+                          "ts": 1744834800000,
+                          "intervalHours": 8
+                        }
+                      }
+                    },
+                    "newestTs": 1744834800000,
+                    "extremes": {
+                      "highest": [],
+                      "lowest": [],
+                      "average": 0.00005
+                    }
+                  },
+                  "meta": {
+                    "total": 2
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "startup",
+        "x-rate-limit-rpm": 80
+      }
+    },
+    "/api/v1/futures/funding/weighted": {
+      "get": {
+        "summary": "OI-weighted funding rate per coin — the honest carry number.",
+        "description": "Plain averages overweight tiny venues. This endpoint weights each exchange's funding rate by its open interest on that instrument, so a 50bps rate on a $1M book doesn't drown out a 2bps rate on a $1B book.",
+        "operationId": "futuresFundingWeighted",
+        "tags": [
+          "Futures"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Rows, sorted weighted-rate desc. Max 200.",
+            "schema": {
+              "type": "number",
+              "default": 50
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": [
+                    {
+                      "base": "BTC",
+                      "weightedRate": 0.00011,
+                      "simpleAvgRate": 0.00013,
+                      "totalOiUsd": 29500000000,
+                      "exchangeCount": 5,
+                      "sampleCount": 7
+                    }
+                  ],
+                  "meta": {
+                    "total": 1,
+                    "limit": 20
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "startup",
+        "x-rate-limit-rpm": 80
+      }
+    },
+    "/api/v1/futures/oi/history": {
+      "get": {
+        "summary": "Per-coin OI history — aggregate + per-exchange split in 5-minute buckets.",
+        "description": "Same shape as `/api/v1/open-interest` in per-coin mode, exposed under the futures namespace. Supply a `source` to narrow the per-source breakdown.",
+        "operationId": "futuresOiHistory",
+        "tags": [
+          "Futures"
+        ],
+        "parameters": [
+          {
+            "name": "coin",
+            "in": "query",
+            "required": true,
+            "description": "Base asset.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "description": "Exchange filter — only applies to per-source breakdown.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "window",
+            "in": "query",
+            "required": false,
+            "description": "Trailing window.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1h",
+                "24h",
+                "7d",
+                "30d"
+              ],
+              "default": "24h"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "base": "BTC",
+                    "window": {
+                      "label": "24h",
+                      "hours": 24
+                    },
+                    "history": [
+                      {
+                        "ts": 1744820400000,
+                        "oiUsd": 28453120000
+                      }
+                    ],
+                    "perSource": {
+                      "binance_futures": [
+                        {
+                          "ts": 1744820400000,
+                          "oiUsd": 12410200000
+                        }
+                      ]
+                    }
+                  },
+                  "meta": {
+                    "total": 1,
+                    "window": "24h"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "startup",
+        "x-rate-limit-rpm": 80
+      }
+    },
+    "/api/v1/futures/oi/by-exchange": {
+      "get": {
+        "summary": "Cross-exchange OI pivot — per-venue sum, share, instrument count.",
+        "description": "Who's holding the open interest right now? Ranks every exchange by aggregate OI (USD). Pass `coin` to scope to one base.",
+        "operationId": "futuresOiByExchange",
+        "tags": [
+          "Futures"
+        ],
+        "parameters": [
+          {
+            "name": "coin",
+            "in": "query",
+            "required": false,
+            "description": "Optional base-asset scope.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": [
+                    {
+                      "source": "binance_futures",
+                      "oiUsd": 12410200000,
+                      "sharePct": 42.1,
+                      "instrumentCount": 1,
+                      "lastTs": 1744834800000
+                    }
+                  ],
+                  "meta": {
+                    "total": 1,
+                    "coin": "BTC",
+                    "aggregateUsd": 29500000000
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "startup",
+        "x-rate-limit-rpm": 80
+      }
+    },
+    "/api/v1/futures/oi/dominance": {
+      "get": {
+        "summary": "Coin-level OI dominance — share of aggregate OI per coin.",
+        "description": "Ranks coins by their share of total derivatives open interest. Useful for BTC-dominance charts and for spotting alts pulling OI.",
+        "operationId": "futuresOiDominance",
+        "tags": [
+          "Futures"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Coins to return. Max 100.",
+            "schema": {
+              "type": "number",
+              "default": 20
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "totals": {
+                      "totalUsd": 29500000000,
+                      "changePct24h": 2.1,
+                      "dominantExchange": "binance_futures",
+                      "dominantSharePct": 42.1,
+                      "instrumentCount": 380,
+                      "sourceCount": 5,
+                      "lastTs": 1744834800000
+                    },
+                    "coins": [
+                      {
+                        "base": "BTC",
+                        "oiUsd": 14200000000,
+                        "dominancePct": 48.1,
+                        "change24hPct": 1.8,
+                        "dominantExchange": "binance_futures",
+                        "dominantSharePct": 41,
+                        "exchangeCount": 5
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1,
+                    "limit": 5
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "startup",
+        "x-rate-limit-rpm": 80
+      }
+    },
+    "/api/v1/futures/volume": {
+      "get": {
+        "summary": "Per-coin 24h futures notional (perp + dated futures).",
+        "description": "Sums the trade table across every non-spot instrument per coin for the last 24h. Optional `coin`/`source` filters scope the view. Ranked volume-desc.",
+        "operationId": "futuresVolume",
+        "tags": [
+          "Futures"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Rows. Max 500.",
+            "schema": {
+              "type": "number",
+              "default": 100
+            }
+          },
+          {
+            "name": "coin",
+            "in": "query",
+            "required": false,
+            "description": "Base asset filter.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "description": "Exchange filter.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": [
+                    {
+                      "base": "BTC",
+                      "volume24hUsd": 85200000000,
+                      "tradeCount": 2100000,
+                      "venueCount": 5,
+                      "instrumentCount": 14,
+                      "lastTs": 1744834800000
+                    }
+                  ],
+                  "meta": {
+                    "total": 1,
+                    "limit": 20
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "startup",
+        "x-rate-limit-rpm": 80
+      }
+    },
+    "/api/v1/futures/premium-index": {
+      "get": {
+        "summary": "Latest mark-vs-index premium snapshot across every connected perp venue.",
+        "description": "The premium index is the percentage gap between the perp's mark price and its index (spot-basket) reference. Persistently positive values across venues = longs crowded (contango); negative = shorts crowded. Returns `tableMissing: true` until the premium_index collector lands.",
+        "operationId": "futuresPremiumIndex",
+        "tags": [
+          "Futures"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "rows": [
+                      {
+                        "source": "binance_futures",
+                        "base": "BTC",
+                        "canonicalSymbol": "BTCUSDT",
+                        "markPrice": 63201.5,
+                        "indexPrice": 63175.2,
+                        "premiumAbs": 26.3,
+                        "premiumPct": 0.0416,
+                        "ts": 1744835000000
+                      }
+                    ],
+                    "tableMissing": false,
+                    "lastTs": 1744835000000
+                  },
+                  "meta": {
+                    "total": 1,
+                    "tableMissing": false
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "startup",
+        "x-rate-limit-rpm": 80
+      }
+    },
+    "/api/v1/futures/premium-index/history": {
+      "get": {
+        "summary": "Per-coin cross-exchange average premium %, bucketed to 5-minute floors.",
+        "description": "Time series for a single base asset — the cross-exchange arithmetic average premium % within each 5-minute bucket. Intended for sparkline / chart rendering.",
+        "operationId": "futuresPremiumIndexHistory",
+        "tags": [
+          "Futures"
+        ],
+        "parameters": [
+          {
+            "name": "coin",
+            "in": "query",
+            "required": true,
+            "description": "Base asset.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Trailing days. Max 90.",
+            "schema": {
+              "type": "number",
+              "default": 30
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "base": "BTC",
+                    "days": 7,
+                    "points": [
+                      {
+                        "ts": 1744220400000,
+                        "premiumPct": 0.031
+                      },
+                      {
+                        "ts": 1744220700000,
+                        "premiumPct": 0.028
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 2,
+                    "days": 7
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "startup",
+        "x-rate-limit-rpm": 80
+      }
+    },
+    "/api/v1/futures/basis": {
+      "get": {
+        "summary": "Latest annualised perp-vs-spot basis per base asset. Cash-and-carry telemetry.",
+        "description": "Basis is the perp mark minus the spot last-trade. A persistently positive basis invites the classic cash-and-carry: long spot, short perp, capture the funding spread. Both legs need collectors — the endpoint returns `tableMissing: true` while either perp_mark_price or spot_price adapters are still pending.",
+        "operationId": "futuresBasis",
+        "tags": [
+          "Futures"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "rows": [
+                      {
+                        "base": "BTC",
+                        "spotPrice": 63120.5,
+                        "perpPrice": 63210,
+                        "basisAbs": 89.5,
+                        "basisPct": 0.1418,
+                        "annualizedPct": 51.75,
+                        "perpSource": "binance_futures",
+                        "spotSource": "binance",
+                        "venueCount": 6,
+                        "ts": 1744835000000
+                      }
+                    ],
+                    "tableMissing": false,
+                    "lastTs": 1744835000000
+                  },
+                  "meta": {
+                    "total": 1,
+                    "tableMissing": false
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "startup",
+        "x-rate-limit-rpm": 80
+      }
+    },
+    "/api/v1/futures/taker-volume": {
+      "get": {
+        "summary": "Taker buy vs sell volume per coin over a trailing window.",
+        "description": "Which side is crossing the spread? Positive `bias` means aggressive buyers ate the offer more than aggressive sellers ate the bid — a real-time aggression gauge that often front-runs spot and OI moves by seconds.",
+        "operationId": "futuresTakerVolume",
+        "tags": [
+          "Futures"
+        ],
+        "parameters": [
+          {
+            "name": "hours",
+            "in": "query",
+            "required": false,
+            "description": "Trailing window, hours. Max 720.",
+            "schema": {
+              "type": "number",
+              "default": 24
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "rows": [
+                      {
+                        "base": "BTC",
+                        "buyVolume": 12400000000,
+                        "sellVolume": 11800000000,
+                        "totalVolume": 24200000000,
+                        "buyShare": 0.5124,
+                        "sellShare": 0.4876,
+                        "bias": 0.0248,
+                        "venueCount": 5,
+                        "lastTs": 1744834800000
+                      }
+                    ],
+                    "windowHours": 24,
+                    "totals": {
+                      "buyVolume": 12400000000,
+                      "sellVolume": 11800000000,
+                      "bias": 0.0248
+                    },
+                    "lastTs": 1744834800000
+                  },
+                  "meta": {
+                    "total": 1,
+                    "windowHours": 24
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "startup",
+        "x-rate-limit-rpm": 80
+      }
+    },
+    "/api/v1/futures/taker-volume/{base}": {
+      "get": {
+        "summary": "Per-coin taker buy/sell split for a single base asset.",
+        "description": "Path-scoped variant of `futures/taker-volume`. Returns 404 when no taker rows have been reported for the asset inside the window.",
+        "operationId": "futuresTakerVolumeBase",
+        "tags": [
+          "Futures"
+        ],
+        "parameters": [
+          {
+            "name": "base",
+            "in": "path",
+            "required": true,
+            "description": "Base asset (BTC, ETH, ...).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "hours",
+            "in": "query",
+            "required": false,
+            "description": "Trailing hours. Max 720.",
+            "schema": {
+              "type": "number",
+              "default": 24
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "base": "BTC",
+                    "buyVolume": 12400000000,
+                    "sellVolume": 11800000000,
+                    "totalVolume": 24200000000,
+                    "buyShare": 0.5124,
+                    "sellShare": 0.4876,
+                    "bias": 0.0248,
+                    "venueCount": 5,
+                    "lastTs": 1744834800000,
+                    "windowHours": 24
+                  },
+                  "meta": {
+                    "total": 1,
+                    "windowHours": 24
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "startup",
+        "x-rate-limit-rpm": 80
+      }
+    },
+    "/api/v1/futures/largest-liquidations": {
+      "get": {
+        "summary": "Top-N single liquidation events by USD notional over a trailing window, filterable.",
+        "description": "Ranks individual liquidation prints by notional ($) inside the window. Filter by coin, exchange, side, or minimum size. Response also carries facets (every coin + exchange reporting in the window) so clients can render filter bars without an additional round-trip.",
+        "operationId": "futuresLargestLiquidations",
+        "tags": [
+          "Futures"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Rows. Max 500.",
+            "schema": {
+              "type": "number",
+              "default": 100
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Trailing window. Max 90.",
+            "schema": {
+              "type": "number",
+              "default": 7
+            }
+          },
+          {
+            "name": "coin",
+            "in": "query",
+            "required": false,
+            "description": "Base asset filter.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "description": "Exchange filter.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "side",
+            "in": "query",
+            "required": false,
+            "description": "Side filter.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "long",
+                "short"
+              ]
+            }
+          },
+          {
+            "name": "minUsd",
+            "in": "query",
+            "required": false,
+            "description": "Minimum notional, USD.",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "rows": [
+                      {
+                        "id": 4421,
+                        "source": "bybit",
+                        "base": "BTC",
+                        "canonicalSymbol": "BTCUSDT",
+                        "side": "long",
+                        "price": 63180.5,
+                        "qtyBase": 120.5,
+                        "qtyUsd": 7610000,
+                        "ts": 1744835000000
+                      }
+                    ],
+                    "totalUsd": 7610000,
+                    "totalLongUsd": 7610000,
+                    "totalShortUsd": 0,
+                    "biggestUsd": 7610000,
+                    "distinctCoins": 1,
+                    "distinctSources": 1,
+                    "windowDays": 7,
+                    "lastTs": 1744835000000,
+                    "facets": {
+                      "coins": [
+                        "BTC"
+                      ],
+                      "sources": [
+                        "bybit"
+                      ]
+                    }
+                  },
+                  "meta": {
+                    "total": 1,
+                    "limit": 100,
+                    "days": 7
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/spot/large-orders": {
+      "get": {
+        "summary": "Whale spot orderbook prints above a configurable notional threshold.",
+        "description": "Scans the `large_order` table for spot-kind instruments, filtered to prints >= `minUsd`. Returns rows + summary totals + facet sets so a UI can render a complete filter bar in one shot. `tableMissing: true` signals the collector hasn't written yet on a fresh install.",
+        "operationId": "spotLargeOrders",
+        "tags": [
+          "Spot"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Rows. Max 500.",
+            "schema": {
+              "type": "number",
+              "default": 50
+            }
+          },
+          {
+            "name": "minUsd",
+            "in": "query",
+            "required": false,
+            "description": "Minimum notional, USD.",
+            "schema": {
+              "type": "number",
+              "default": 500000
+            }
+          },
+          {
+            "name": "coin",
+            "in": "query",
+            "required": false,
+            "description": "Base asset filter.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "description": "Exchange filter.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "side",
+            "in": "query",
+            "required": false,
+            "description": "Orderbook side.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "bid",
+                "ask"
+              ]
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "rows": [
+                      {
+                        "id": 128,
+                        "source": "binance",
+                        "base": "BTC",
+                        "quote": "USDT",
+                        "side": "bid",
+                        "price": 63120.5,
+                        "qtyBase": 25.4,
+                        "qtyUsd": 1603260,
+                        "ts": 1744835000000,
+                        "status": "open"
+                      }
+                    ],
+                    "tableMissing": false,
+                    "totalUsd": 1603260,
+                    "bidUsd": 1603260,
+                    "askUsd": 0,
+                    "distinctCoins": 1,
+                    "distinctSources": 1,
+                    "lastTs": 1744835000000,
+                    "facets": {
+                      "coins": [
+                        "BTC"
+                      ],
+                      "sources": [
+                        "binance"
+                      ]
+                    },
+                    "appliedMinUsd": 1000000,
+                    "appliedLimit": 50
+                  },
+                  "meta": {
+                    "total": 1,
+                    "limit": 50,
+                    "minUsd": 1000000,
+                    "tableMissing": false
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/spot/volumes": {
+      "get": {
+        "summary": "Per-coin 24h spot volume leaderboard across all tracked venues.",
+        "description": "Sums the spot `trade` table per base asset across every venue in the last 24h. Returns notional, trade count, distinct venue count, and freshness timestamp. Ranked volume-desc.",
+        "operationId": "spotVolumes",
+        "tags": [
+          "Spot"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Rows. Max 500.",
+            "schema": {
+              "type": "number",
+              "default": 100
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": [
+                    {
+                      "base": "BTC",
+                      "volume24hUsd": 18200000000,
+                      "tradeCount": 820000,
+                      "venueCount": 4,
+                      "lastTs": 1744834800000
+                    }
+                  ],
+                  "meta": {
+                    "total": 1,
+                    "limit": 20
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/spot/exchanges": {
+      "get": {
+        "summary": "Per-venue spot rankings — 24h volume, pair count, share-of-total.",
+        "description": "Spot equivalent of `/api/v1/exchanges`, scoped to the spot slice of the trade table.",
+        "operationId": "spotExchanges",
+        "tags": [
+          "Spot"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Rows. Max 200.",
+            "schema": {
+              "type": "number",
+              "default": 50
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": [
+                    {
+                      "source": "binance",
+                      "volume24hUsd": 8200000000,
+                      "tradeCount": 420000,
+                      "pairCount": 210,
+                      "coinCount": 185,
+                      "sharePct": 35.1,
+                      "lastTs": 1744834800000
+                    }
+                  ],
+                  "meta": {
+                    "total": 1,
+                    "limit": 50
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/spot/exchanges/{source}": {
+      "get": {
+        "summary": "Single-venue spot rollup.",
+        "description": "Same row shape as `/api/v1/spot/exchanges` but scoped to a single source. Returns 404 when the venue has no spot activity in the last 24h.",
+        "operationId": "spotExchangeDetail",
+        "tags": [
+          "Spot"
+        ],
+        "parameters": [
+          {
+            "name": "source",
+            "in": "path",
+            "required": true,
+            "description": "Exchange slug (e.g. `binance`).",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "source": "binance",
+                    "volume24hUsd": 8200000000,
+                    "tradeCount": 420000,
+                    "pairCount": 210,
+                    "coinCount": 185,
+                    "sharePct": 35.1,
+                    "lastTs": 1744834800000
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/spot/pairs": {
+      "get": {
+        "summary": "Directory of tracked spot pairs with venue coverage + 24h volume.",
+        "description": "Every spot instrument we ingest, grouped by canonical symbol, with distinct venue count and 24h notional. Sorted volume-desc.",
+        "operationId": "spotPairs",
+        "tags": [
+          "Spot"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Rows. Max 2000.",
+            "schema": {
+              "type": "number",
+              "default": 200
+            }
+          },
+          {
+            "name": "base",
+            "in": "query",
+            "required": false,
+            "description": "Optional base filter.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": [
+                    {
+                      "canonicalSymbol": "BTCUSDT",
+                      "base": "BTC",
+                      "quote": "USDT",
+                      "venueCount": 4,
+                      "volume24hUsd": 18200000000,
+                      "lastTs": 1744834800000
+                    }
+                  ],
+                  "meta": {
+                    "total": 1,
+                    "limit": 200
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/spot/price/{base}": {
+      "get": {
+        "summary": "Latest spot price for a single coin across every reporting venue.",
+        "description": "Returns the freshest spot tick (`bestPrice`/`bestSource`/`bestTs`) plus the full per-venue comparison list.",
+        "operationId": "spotPriceBase",
+        "tags": [
+          "Spot"
+        ],
+        "parameters": [
+          {
+            "name": "base",
+            "in": "path",
+            "required": true,
+            "description": "Base asset (e.g. `BTC`).",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "base": "BTC",
+                    "bestPrice": 63180.5,
+                    "bestSource": "binance",
+                    "bestTs": 1744834810000,
+                    "venues": [
+                      {
+                        "source": "binance",
+                        "price": 63180.5,
+                        "ts": 1744834810000,
+                        "canonicalSymbol": "BTCUSDT"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/coins": {
+      "get": {
+        "summary": "One-call rollup table — every base asset we track, blended price, 24h change, volume, OI, and average funding.",
+        "description": "The canonical cross-asset rollup: one row per base asset with a blended price anchor (Hyperliquid-preferred), 24h change %, 24h notional USD volume, aggregate open interest with 24h delta, and a venue-averaged funding rate. Backed by `getCoinsOverview` — the same helper that powers `/coins` on the web surface, so numbers reconcile 1:1 with the on-page table.",
+        "operationId": "coinsList",
+        "tags": [
+          "Coins"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Rows. Max 500.",
+            "schema": {
+              "type": "number",
+              "default": 100
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "description": "Sort field.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "rank",
+                "price",
+                "change24h",
+                "volume",
+                "oi",
+                "oiChange",
+                "funding"
+              ],
+              "default": "rank"
+            }
+          },
+          {
+            "name": "dir",
+            "in": "query",
+            "required": false,
+            "description": "Sort direction.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "default": "desc"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": [
+                    {
+                      "base": "BTC",
+                      "price": 63180.5,
+                      "priceChange24hPct": 1.82,
+                      "volume24hUsd": 28450000000,
+                      "oiTotalUsd": 24100000000,
+                      "oiChange24hPct": 2.4,
+                      "avgFundingRate": 0.000108,
+                      "rank": 1
+                    },
+                    {
+                      "base": "ETH",
+                      "price": 3280.15,
+                      "priceChange24hPct": -0.55,
+                      "volume24hUsd": 14200000000,
+                      "oiTotalUsd": 12400000000,
+                      "oiChange24hPct": -0.8,
+                      "avgFundingRate": 0.000092,
+                      "rank": 2
+                    }
+                  ],
+                  "meta": {
+                    "total": 2,
+                    "limit": 3,
+                    "sort": "volume",
+                    "dir": "desc"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/coins/{base}": {
+      "get": {
+        "summary": "Single-coin deep view — overview row + per-exchange OI, funding, and 24h volume.",
+        "description": "Deep detail for a single base asset. Returns the `getCoinsOverview` row for this coin plus three per-exchange breakdowns (latest OI in USD, latest funding rate + interval, 24h notional volume). Responds 404 `UNKNOWN_COIN` when the symbol is unknown or has zero data — clients should treat that as 'try again in a few minutes' for brand-new listings.",
+        "operationId": "coinsDetail",
+        "tags": [
+          "Coins"
+        ],
+        "parameters": [
+          {
+            "name": "base",
+            "in": "path",
+            "required": true,
+            "description": "Base asset code (BTC, ETH, SOL…). Case-insensitive; uppercased on the wire.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "base": "BTC",
+                    "overview": {
+                      "base": "BTC",
+                      "price": 63180.5,
+                      "priceChange24hPct": 1.82,
+                      "volume24hUsd": 28450000000,
+                      "oiTotalUsd": 24100000000,
+                      "oiChange24hPct": 2.4,
+                      "avgFundingRate": 0.000108,
+                      "rank": 1
+                    },
+                    "perExchange": {
+                      "openInterest": [
+                        {
+                          "source": "binance_futures",
+                          "oiUsd": 9800000000
+                        },
+                        {
+                          "source": "bybit",
+                          "oiUsd": 6200000000
+                        }
+                      ],
+                      "funding": [
+                        {
+                          "source": "binance_futures",
+                          "rate": 0.0001,
+                          "intervalHours": 8,
+                          "ts": 1744834800000
+                        }
+                      ],
+                      "volume24h": [
+                        {
+                          "source": "binance_futures",
+                          "volumeUsd": 14200000000
+                        }
+                      ]
+                    }
+                  },
+                  "meta": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/coins/{base}/exchanges": {
+      "get": {
+        "summary": "Per-exchange snapshot for a single base asset — one row per venue.",
+        "description": "Folds the three per-exchange breakdowns from `/coins/{base}` into a single denormalised row per venue. Each row carries latest OI (USD), 24h notional volume (USD), latest funding rate + interval, and the distinct instrument count covering this base on that venue. Venues with zero activity across every metric are dropped. Sorted by OI descending.",
+        "operationId": "coinsExchanges",
+        "tags": [
+          "Coins"
+        ],
+        "parameters": [
+          {
+            "name": "base",
+            "in": "path",
+            "required": true,
+            "description": "Base asset code.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "base": "BTC",
+                    "exchanges": [
+                      {
+                        "source": "binance_futures",
+                        "oiUsd": 9800000000,
+                        "volume24hUsd": 14200000000,
+                        "fundingRate": 0.0001,
+                        "fundingIntervalHours": 8,
+                        "fundingTs": 1744834800000,
+                        "instrumentCount": 2
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/coins/{base}/history": {
+      "get": {
+        "summary": "OHLCV history for a single coin, bucketed to the requested interval across all venues.",
+        "description": "Cross-venue OHLCV rollup built from `candle_1m` rows. For each bucket we fold (first open, MAX high, MIN low, last close, SUM quote volume, SUM trade count) across every instrument under this base. Use this when you want a single line for the whole asset class; for venue-specific bars use `/api/v1/candles` with an `exchange` filter.",
+        "operationId": "coinsHistory",
+        "tags": [
+          "Coins"
+        ],
+        "parameters": [
+          {
+            "name": "base",
+            "in": "path",
+            "required": true,
+            "description": "Base asset code.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "interval",
+            "in": "query",
+            "required": false,
+            "description": "Bucket size.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1m",
+                "5m",
+                "15m",
+                "1h",
+                "4h",
+                "1d"
+              ],
+              "default": "1h"
+            }
+          },
+          {
+            "name": "hours",
+            "in": "query",
+            "required": false,
+            "description": "Trailing window in hours. Max 720 (30 days).",
+            "schema": {
+              "type": "number",
+              "default": 24
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Row cap. Max 5000.",
+            "schema": {
+              "type": "number",
+              "default": 500
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "base": "BTC",
+                    "interval": "1h",
+                    "hours": 24,
+                    "candles": [
+                      {
+                        "ts": 1744834800000,
+                        "open": 62900.1,
+                        "high": 63250,
+                        "low": 62850,
+                        "close": 63180.5,
+                        "volumeUsd": 1250000000,
+                        "trades": 48210
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1,
+                    "interval": "1h",
+                    "hours": 24
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/coins/heatmap": {
+      "get": {
+        "summary": "Pre-shaped tiles for the market heatmap widget — one tile per coin.",
+        "description": "Returns the exact tile-list the `/heatmap` page consumes. Each tile has `weight` (positive number for sizing — either 24h volume or aggregate OI) and `changePct` (24h % change, used for colouring). Coins with a null price change are excluded so the colour scale isn't skewed by blanks. Pass `weightBy=oi` for the OI-sized variant.",
+        "operationId": "coinsHeatmap",
+        "tags": [
+          "Coins"
+        ],
+        "parameters": [
+          {
+            "name": "weightBy",
+            "in": "query",
+            "required": false,
+            "description": "Metric that drives tile size.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "volume",
+                "oi"
+              ],
+              "default": "volume"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max tiles. Max 500.",
+            "schema": {
+              "type": "number",
+              "default": 100
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "weightBy": "volume",
+                    "tiles": [
+                      {
+                        "base": "BTC",
+                        "weight": 28450000000,
+                        "changePct": 1.82,
+                        "price": 63180.5,
+                        "volume24hUsd": 28450000000,
+                        "oiTotalUsd": 24100000000
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1,
+                    "weightBy": "volume",
+                    "limit": 50
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/coins/top-movers": {
+      "get": {
+        "summary": "24h gainers + losers, pre-filtered by minimum volume floor.",
+        "description": "Returns the exact pair of arrays the `/coins` home-panel consumes: top-N gainers and top-N losers by 24h % change, filtered to a minimum 24h volume floor (`MIN_MOVER_VOLUME_USD`) so microcap noise doesn't dominate. Gainers descend by change%, losers ascend.",
+        "operationId": "coinsTopMovers",
+        "tags": [
+          "Coins"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Rows per side. Max 50.",
+            "schema": {
+              "type": "number",
+              "default": 5
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "gainers": [
+                      {
+                        "base": "WIF",
+                        "price": 2.41,
+                        "priceChange24hPct": 18.4,
+                        "volume24hUsd": 380000000,
+                        "oiTotalUsd": 120000000,
+                        "oiChange24hPct": 4.1,
+                        "avgFundingRate": 0.00021,
+                        "rank": 27
+                      }
+                    ],
+                    "losers": [
+                      {
+                        "base": "TIA",
+                        "price": 4.02,
+                        "priceChange24hPct": -9.8,
+                        "volume24hUsd": 210000000,
+                        "oiTotalUsd": 98000000,
+                        "oiChange24hPct": -2.6,
+                        "avgFundingRate": -0.00014,
+                        "rank": 42
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "gainers": 1,
+                    "losers": 1,
+                    "limit": 5
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/candles": {
+      "get": {
+        "summary": "OHLCV candles aggregated from 1-minute bars — accepts any venue/instrument.",
+        "description": "Aggregates 1-minute OHLCV rows from the `candle_1m` table up to the requested interval. The bucket fold is (first open, MAX high, MIN low, last close, SUM base volume) so multi-minute bars are consistent with the underlying 1m stream. Pass `symbol` as a canonical `BTC-USDT-PERP` or a bare base (`BTC`) — a bare base resolves to the preferred perp for that asset. Unknown symbols return `[]`, not an error.",
+        "operationId": "candles",
+        "tags": [
+          "Markets"
+        ],
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "query",
+            "required": true,
+            "description": "Canonical symbol or bare base (e.g. `BTC` or `BTC-USDT-PERP`).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "exchange",
+            "in": "query",
+            "required": false,
+            "description": "Optional source filter (e.g. `binance_futures`). Omit for any venue.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "interval",
+            "in": "query",
+            "required": false,
+            "description": "Candle interval.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1m",
+                "5m",
+                "15m",
+                "1h",
+                "4h",
+                "1d",
+                "1w"
+              ],
+              "default": "1h"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": false,
+            "description": "Lower bound, ms since epoch.",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": false,
+            "description": "Upper bound, ms since epoch.",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max candles. Hard cap 5000.",
+            "schema": {
+              "type": "number",
+              "default": 500
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": [
+                    {
+                      "time": 1744834800,
+                      "open": 62900.1,
+                      "high": 63250,
+                      "low": 62850,
+                      "close": 63180.5,
+                      "volume": 1820.4
+                    }
+                  ],
+                  "meta": {
+                    "count": 1,
+                    "symbol": "BTC",
+                    "canonical": "BTC-USDT-PERP",
+                    "exchange": null,
+                    "interval": "1h",
+                    "intervalMs": 3600000,
+                    "from": null,
+                    "to": null
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/exchanges": {
+      "get": {
+        "summary": "Venue directory + rollup — OI, 24h volume, coin count, status.",
+        "description": "One row per upstream exchange with aggregate OI, 24h notional, active coin count, last heartbeat, and derived status. Same query powering `/markets/exchanges`.",
+        "operationId": "exchangesList",
+        "tags": [
+          "Exchanges"
+        ],
+        "parameters": [
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "description": "Sort key.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "oi",
+                "volume",
+                "coins",
+                "heartbeat"
+              ],
+              "default": "oi"
+            }
+          },
+          {
+            "name": "dir",
+            "in": "query",
+            "required": false,
+            "description": "Sort direction.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "default": "desc"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Rows. Max 200.",
+            "schema": {
+              "type": "number",
+              "default": 50
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": [
+                    {
+                      "source": "binance_futures",
+                      "displayName": "Binance Futures",
+                      "type": "CEX",
+                      "oiUsd": 12410200000,
+                      "oiSharePct": 42.1,
+                      "volume24hUsd": 85200000000,
+                      "volumeSharePct": 38.2,
+                      "coinCount": 210,
+                      "lastHeartbeatTs": 1744835110000,
+                      "status": "live"
+                    }
+                  ],
+                  "meta": {
+                    "total": 1,
+                    "limit": 5,
+                    "sort": "oi",
+                    "dir": "desc"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/exchanges/{source}": {
+      "get": {
+        "summary": "Single-exchange identity + rollup row.",
+        "description": "Same shape as one row from `/api/v1/exchanges`, scoped to a single venue. 404 when the source has never reported data.",
+        "operationId": "exchangesDetail",
+        "tags": [
+          "Exchanges"
+        ],
+        "parameters": [
+          {
+            "name": "source",
+            "in": "path",
+            "required": true,
+            "description": "Exchange slug.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "source": "binance_futures",
+                    "displayName": "Binance Futures",
+                    "type": "CEX",
+                    "oiUsd": 12410200000,
+                    "oiSharePct": 42.1,
+                    "volume24hUsd": 85200000000,
+                    "volumeSharePct": 38.2,
+                    "coinCount": 210,
+                    "lastHeartbeatTs": 1744835110000,
+                    "status": "live"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/exchanges/{source}/instruments": {
+      "get": {
+        "summary": "Per-exchange instrument table — OI + 24h notional for each instrument.",
+        "description": "Granular drill-in — one row per instrument the venue has been active on, with latest OI (USD), 24h trade notional, and latest trade/OI timestamps. Sorted OI-desc, volume-desc.",
+        "operationId": "exchangesInstruments",
+        "tags": [
+          "Exchanges"
+        ],
+        "parameters": [
+          {
+            "name": "source",
+            "in": "path",
+            "required": true,
+            "description": "Exchange slug.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Rows. Max 500.",
+            "schema": {
+              "type": "number",
+              "default": 100
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Pagination offset.",
+            "schema": {
+              "type": "number",
+              "default": 0
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": [
+                    {
+                      "instrumentId": 12,
+                      "canonicalSymbol": "BTCUSDT",
+                      "base": "BTC",
+                      "quote": "USDT",
+                      "kind": "perp",
+                      "oiUsd": 5800000000,
+                      "volume24hUsd": 41200000000,
+                      "lastTradeTs": 1744834810000,
+                      "lastOiTs": 1744834800000
+                    }
+                  ],
+                  "meta": {
+                    "total": 1,
+                    "limit": 5,
+                    "offset": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/exchanges/{source}/stats": {
+      "get": {
+        "summary": "Aggregate OI/volume/funding/heartbeat summary for one exchange.",
+        "description": "Adds a cross-instrument average funding rate and the total distinct instrument count to the identity row. Useful for single-venue health tiles.",
+        "operationId": "exchangesStats",
+        "tags": [
+          "Exchanges"
+        ],
+        "parameters": [
+          {
+            "name": "source",
+            "in": "path",
+            "required": true,
+            "description": "Exchange slug.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "source": "binance_futures",
+                    "displayName": "Binance Futures",
+                    "type": "CEX",
+                    "oiUsd": 12410200000,
+                    "volume24hUsd": 85200000000,
+                    "coinCount": 210,
+                    "instrumentCount": 228,
+                    "avgFundingRate": 0.00011,
+                    "lastHeartbeatTs": 1744835110000,
+                    "status": "live"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/instruments": {
+      "get": {
+        "summary": "Paginated instrument directory — richer sibling of `/api/v1/symbols`.",
+        "description": "Same underlying instrument table as `/api/v1/symbols`, exposed with consistent filter semantics under the instruments namespace.",
+        "operationId": "instrumentsList",
+        "tags": [
+          "Meta"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Rows per page. Max 5000.",
+            "schema": {
+              "type": "number",
+              "default": 500
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Pagination offset.",
+            "schema": {
+              "type": "number",
+              "default": 0
+            }
+          },
+          {
+            "name": "base",
+            "in": "query",
+            "required": false,
+            "description": "Exact base-asset filter.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "kind",
+            "in": "query",
+            "required": false,
+            "description": "Instrument family.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "perp",
+                "spot",
+                "future",
+                "option"
+              ]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "description": "Prefix search on canonical symbol.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": [
+                    {
+                      "id": 12,
+                      "canonicalSymbol": "BTCUSDT",
+                      "base": "BTC",
+                      "quote": "USDT",
+                      "kind": "perp",
+                      "expiry": null,
+                      "strike": null,
+                      "optionType": null
+                    }
+                  ],
+                  "meta": {
+                    "total": 1,
+                    "limit": 5,
+                    "offset": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "anonymous",
+        "x-rate-limit-rpm": 10
+      }
+    },
+    "/api/v1/instruments/{symbol}": {
+      "get": {
+        "summary": "Instrument detail + activity counters (trade/OI/funding).",
+        "description": "Resolve one instrument by canonical symbol. The `activity` bag is the fast way to tell whether an instrument is actively reporting — non-zero counts and fresh `last*Ts` values mean the pipeline is healthy.",
+        "operationId": "instrumentsDetail",
+        "tags": [
+          "Meta"
+        ],
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "path",
+            "required": true,
+            "description": "Canonical symbol (e.g. `BTCUSDT`).",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "id": 12,
+                    "canonicalSymbol": "BTCUSDT",
+                    "base": "BTC",
+                    "quote": "USDT",
+                    "kind": "perp",
+                    "expiry": null,
+                    "strike": null,
+                    "optionType": null,
+                    "activity": {
+                      "tradeCount": 1250000,
+                      "openInterestCount": 48200,
+                      "fundingCount": 620,
+                      "lastTradeTs": 1744834810000,
+                      "lastOiTs": 1744834800000,
+                      "lastFundingTs": 1744833600000
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "anonymous",
+        "x-rate-limit-rpm": 10
+      }
+    },
+    "/api/v1/instruments/search": {
+      "get": {
+        "summary": "Prefix search across canonical symbol and base — for typeahead.",
+        "description": "Sanitised prefix LIKE query. User-supplied `%`/`_` wildcards are stripped so `q=%` can't turn into a table scan.",
+        "operationId": "instrumentsSearch",
+        "tags": [
+          "Meta"
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Prefix query.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max rows. Max 100.",
+            "schema": {
+              "type": "number",
+              "default": 25
+            }
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": [
+                    {
+                      "id": 12,
+                      "canonicalSymbol": "BTCUSDT",
+                      "base": "BTC",
+                      "quote": "USDT",
+                      "kind": "perp",
+                      "expiry": null,
+                      "strike": null,
+                      "optionType": null
+                    }
+                  ],
+                  "meta": {
+                    "total": 1,
+                    "limit": 5
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "anonymous",
+        "x-rate-limit-rpm": 10
+      }
+    },
+    "/api/v1/options/{underlying}": {
+      "get": {
+        "summary": "Deribit options chain, Greeks, put/call ratio, and max-pain strike for BTC or ETH.",
+        "description": "Returns the latest Deribit chain for BTC or ETH — every strike, both calls and puts, with Greeks attached. Use this to visualise the term structure, compute dealer gamma, or just cherry-pick ATM IVs. The endpoint also computes put/call ratio (by OI) and max-pain for you. Without an `expiry` query we render the nearest upcoming contract.",
+        "operationId": "optionsChain",
+        "tags": [
+          "Options"
+        ],
+        "parameters": [
+          {
+            "name": "underlying",
+            "in": "path",
+            "required": true,
+            "description": "Which asset's chain.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "BTC",
+                "ETH"
+              ]
+            }
+          },
+          {
+            "name": "expiry",
+            "in": "query",
+            "required": false,
+            "description": "Deribit `DDMMMYY` label (e.g. `25APR25`). Omit to get the nearest upcoming expiry.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "underlying": "BTC",
+                    "expiry": "25APR25",
+                    "expiries": [
+                      "25APR25",
+                      "02MAY25",
+                      "09MAY25",
+                      "27JUN25"
+                    ],
+                    "chain": [
+                      {
+                        "strike": 60000,
+                        "expiry": "25APR25",
+                        "optionType": "C",
+                        "markPrice": 0.052,
+                        "markIv": 0.58,
+                        "delta": 0.67,
+                        "gamma": 0.00011,
+                        "vega": 45.2,
+                        "theta": -22.1,
+                        "openInterest": 1280.5,
+                        "volume24h": 210,
+                        "underlyingPrice": 63150,
+                        "ts": 1744834800000
+                      }
+                    ],
+                    "pcr": 0.83,
+                    "maxPain": 62000,
+                    "lastTs": 1744834800000
+                  },
+                  "meta": {
+                    "total": 1
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/options/{underlying}/chain": {
+      "get": {
+        "summary": "Latest Deribit chain snapshot — optionally narrowed to one expiry.",
+        "description": "Returns the full chain for the latest snapshot, or just the rows matching a single `expiry`. Equivalent to the root /options/{underlying} endpoint minus the derived PCR + max-pain fields (use the dedicated endpoints for those).",
+        "operationId": "optionsChainLatest",
+        "tags": [
+          "Options"
+        ],
+        "parameters": [
+          {
+            "name": "underlying",
+            "in": "path",
+            "required": true,
+            "description": "BTC or ETH.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "BTC",
+                "ETH"
+              ]
+            }
+          },
+          {
+            "name": "expiry",
+            "in": "query",
+            "required": false,
+            "description": "Deribit `DDMMMYY` label (e.g. `25APR25`). Omit for the full chain.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "underlying": "BTC",
+                    "expiry": "25APR25",
+                    "asOf": 1744834800000,
+                    "chain": []
+                  },
+                  "meta": {
+                    "total": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/options/{underlying}/iv": {
+      "get": {
+        "summary": "Per-strike IV at the latest snapshot for a single expiry.",
+        "description": "Resolves `expiry` to a concrete chain slice (nearest upcoming expiry if omitted). Calls and puts are distinct rows so clients can plot smile curves side-by-side.",
+        "operationId": "optionsIv",
+        "tags": [
+          "Options"
+        ],
+        "parameters": [
+          {
+            "name": "underlying",
+            "in": "path",
+            "required": true,
+            "description": "BTC or ETH.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "BTC",
+                "ETH"
+              ]
+            }
+          },
+          {
+            "name": "expiry",
+            "in": "query",
+            "required": false,
+            "description": "Deribit `DDMMMYY`. Defaults to nearest upcoming live expiry.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "underlying": "BTC",
+                    "expiry": "25APR25",
+                    "points": []
+                  },
+                  "meta": {
+                    "total": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/options/{underlying}/iv/history": {
+      "get": {
+        "summary": "IV history for a single (expiry, strike) tuple — ATM by default.",
+        "description": "Historical mean IV at a fixed (expiry, strike). Omit `strike` to auto-resolve the ATM strike at the most recent snapshot. Call+put IV at the same ts are averaged to smooth smile-skew noise.",
+        "operationId": "optionsIvHistory",
+        "tags": [
+          "Options"
+        ],
+        "parameters": [
+          {
+            "name": "underlying",
+            "in": "path",
+            "required": true,
+            "description": "BTC or ETH.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "BTC",
+                "ETH"
+              ]
+            }
+          },
+          {
+            "name": "expiry",
+            "in": "query",
+            "required": true,
+            "description": "Deribit `DDMMMYY` label.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "strike",
+            "in": "query",
+            "required": false,
+            "description": "Exact strike. Omit for ATM.",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max points (1-5000).",
+            "schema": {
+              "type": "number",
+              "default": 500
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "underlying": "BTC",
+                    "expiry": "27JUN25",
+                    "strike": 70000,
+                    "points": []
+                  },
+                  "meta": {
+                    "total": 0,
+                    "limit": 200
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/options/{underlying}/iv/surface": {
+      "get": {
+        "summary": "Full IV surface — strikes × expiries with per-cell IV.",
+        "description": "2-D IV surface bounded to ATM ± `band` (default ±40%) so the grid stays legible. Each cell carries call IV, put IV, and their average.",
+        "operationId": "optionsIvSurface",
+        "tags": [
+          "Options"
+        ],
+        "parameters": [
+          {
+            "name": "underlying",
+            "in": "path",
+            "required": true,
+            "description": "BTC or ETH.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "BTC",
+                "ETH"
+              ]
+            }
+          },
+          {
+            "name": "band",
+            "in": "query",
+            "required": false,
+            "description": "Strike band fraction around ATM. (0, 1].",
+            "schema": {
+              "type": "number",
+              "default": 0.4
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "underlying": "BTC",
+                    "band": 0.4,
+                    "strikes": [],
+                    "expiries": [],
+                    "cells": []
+                  },
+                  "meta": {
+                    "total": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/options/{underlying}/iv-rank": {
+      "get": {
+        "summary": "IV RANK — where today's ATM IV sits in its rolling N-day range.",
+        "description": "0 = lowest in the window, 100 = highest. ATM samples are pulled per-snapshot as the strike nearest to that snapshot's underlying price.",
+        "operationId": "optionsIvRank",
+        "tags": [
+          "Options"
+        ],
+        "parameters": [
+          {
+            "name": "underlying",
+            "in": "path",
+            "required": true,
+            "description": "BTC or ETH.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "BTC",
+                "ETH"
+              ]
+            }
+          },
+          {
+            "name": "windowDays",
+            "in": "query",
+            "required": false,
+            "description": "Lookback window (7-1825).",
+            "schema": {
+              "type": "number",
+              "default": 365
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "underlying": "BTC",
+                    "currentIv": 58,
+                    "minIv": 42,
+                    "maxIv": 92,
+                    "rankPct": 32,
+                    "windowDays": 180,
+                    "sampleCount": 3120,
+                    "asOf": 1744834800000
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/options/{underlying}/dvol": {
+      "get": {
+        "summary": "Deribit Volatility Index (DVOL) — current + history.",
+        "description": "DVOL is Deribit's 30-day forward IV index. We ingest it into `sentiment_index` under `btc_dvol` / `eth_dvol`. This endpoint returns the latest reading plus a bounded history.",
+        "operationId": "optionsDvol",
+        "tags": [
+          "Options"
+        ],
+        "parameters": [
+          {
+            "name": "underlying",
+            "in": "path",
+            "required": true,
+            "description": "BTC or ETH.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "BTC",
+                "ETH"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max history points (1-5000).",
+            "schema": {
+              "type": "number",
+              "default": 500
+            }
+          },
+          {
+            "name": "windowDays",
+            "in": "query",
+            "required": false,
+            "description": "Cap history to last N days.",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "underlying": "BTC",
+                    "current": {
+                      "value": 58.4,
+                      "ts": 1744834800000
+                    },
+                    "history": []
+                  },
+                  "meta": {
+                    "total": 0,
+                    "limit": 90
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/options/{underlying}/greeks": {
+      "get": {
+        "summary": "Greeks snapshot — every strike in the latest chain.",
+        "description": "Delta, gamma, vega, theta per instrument. Nulls are the norm — Deribit's `book_summary` endpoint doesn't populate Greeks; they appear only when the worker has back-filled via `public/ticker` (usually ATM ± N strikes). Pass `?instrument=BTC-27JUN25-70000-C` to fetch a single row.",
+        "operationId": "optionsGreeks",
+        "tags": [
+          "Options"
+        ],
+        "parameters": [
+          {
+            "name": "underlying",
+            "in": "path",
+            "required": true,
+            "description": "BTC or ETH.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "BTC",
+                "ETH"
+              ]
+            }
+          },
+          {
+            "name": "instrument",
+            "in": "query",
+            "required": false,
+            "description": "Canonical Deribit instrument name. 404 if absent from the latest snapshot.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "underlying": "BTC",
+                    "instrument": {
+                      "instrumentName": "BTC-27JUN25-70000-C",
+                      "expiry": "27JUN25",
+                      "strike": 70000,
+                      "optionType": "C",
+                      "delta": 0.52,
+                      "gamma": 0.00013,
+                      "vega": 42.1,
+                      "theta": -18.7,
+                      "markIv": 62,
+                      "underlyingPrice": 69800
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "professional",
+        "x-rate-limit-rpm": 1200
+      }
+    },
+    "/api/v1/options/{underlying}/max-pain": {
+      "get": {
+        "summary": "Max-pain strike per expiry for the N next upcoming expiries.",
+        "description": "Max pain is the strike that would minimise total in-the-money OI at settlement. Retail folklore, not a forecast — useful as a sentiment anchor.",
+        "operationId": "optionsMaxPain",
+        "tags": [
+          "Options"
+        ],
+        "parameters": [
+          {
+            "name": "underlying",
+            "in": "path",
+            "required": true,
+            "description": "BTC or ETH.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "BTC",
+                "ETH"
+              ]
+            }
+          },
+          {
+            "name": "expiries",
+            "in": "query",
+            "required": false,
+            "description": "How many upcoming expiries to include (1-20).",
+            "schema": {
+              "type": "number",
+              "default": 3
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "underlying": "BTC",
+                    "asOf": 1744834800000,
+                    "current": {
+                      "expiry": "25APR25",
+                      "strike": 62000,
+                      "painUsd": 1200000
+                    },
+                    "upcoming": [],
+                    "underlyingPrice": 63150
+                  },
+                  "meta": {
+                    "total": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/options/{underlying}/max-pain/history": {
+      "get": {
+        "summary": "Historical max-pain strike — nearest expiry or per-expiry flavours.",
+        "description": "Backed by `sentiment_index` rows written each cycle under `<ccy>_max_pain_<DDMMMYY>`. `flavour=nearest` (default) collapses to a single nearest-live-expiry series; `flavour=per-expiry` returns every (ts, expiry, strike) tuple from the last N days.",
+        "operationId": "optionsMaxPainHistory",
+        "tags": [
+          "Options"
+        ],
+        "parameters": [
+          {
+            "name": "underlying",
+            "in": "path",
+            "required": true,
+            "description": "BTC or ETH.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "BTC",
+                "ETH"
+              ]
+            }
+          },
+          {
+            "name": "flavour",
+            "in": "query",
+            "required": false,
+            "description": "Shape of the returned payload.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "nearest",
+                "per-expiry"
+              ],
+              "default": "nearest"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Per-expiry window (1-365).",
+            "schema": {
+              "type": "number",
+              "default": 30
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Nearest-flavour cap (1-5000).",
+            "schema": {
+              "type": "number",
+              "default": 500
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "underlying": "BTC",
+                    "flavour": "nearest",
+                    "points": []
+                  },
+                  "meta": {
+                    "total": 0,
+                    "limit": 200
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/options/{underlying}/pcr": {
+      "get": {
+        "summary": "Put/Call ratio snapshot — underlying total + per-expiry breakdown.",
+        "description": "Current OI-PCR and volume-PCR aggregated across every listed expiry, plus the per-expiry term-structure slice. Divergence between OI and vol PCR signals slow-building hedges vs reactive flow.",
+        "operationId": "optionsPcr",
+        "tags": [
+          "Options"
+        ],
+        "parameters": [
+          {
+            "name": "underlying",
+            "in": "path",
+            "required": true,
+            "description": "BTC or ETH.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "BTC",
+                "ETH"
+              ]
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "underlying": "BTC",
+                    "asOf": 1744834800000,
+                    "oiPcr": 0.83,
+                    "volPcr": 0.72,
+                    "callOi": 120000,
+                    "putOi": 99600,
+                    "callVol": 52000,
+                    "putVol": 37400,
+                    "byExpiry": []
+                  },
+                  "meta": {
+                    "total": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/options/{underlying}/pcr/history": {
+      "get": {
+        "summary": "Put/Call ratio history — OI PCR + volume PCR over N days.",
+        "description": "Derived from `options_chain` snapshots — each distinct ts gives one aggregate call / put OI + volume pair, from which OI-PCR and Volume-PCR are computed. Downsampled to `maxPoints` so SVG charts render crisply.",
+        "operationId": "optionsPcrHistory",
+        "tags": [
+          "Options"
+        ],
+        "parameters": [
+          {
+            "name": "underlying",
+            "in": "path",
+            "required": true,
+            "description": "BTC or ETH.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "BTC",
+                "ETH"
+              ]
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Lookback window (1-365).",
+            "schema": {
+              "type": "number",
+              "default": 30
+            }
+          },
+          {
+            "name": "maxPoints",
+            "in": "query",
+            "required": false,
+            "description": "Downsample cap (10-2000).",
+            "schema": {
+              "type": "number",
+              "default": 180
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "underlying": "BTC",
+                    "days": 14,
+                    "maxPoints": 180,
+                    "current": {
+                      "oiPcr": 0.83,
+                      "volPcr": 0.72
+                    },
+                    "history": [],
+                    "byExpiry": []
+                  },
+                  "meta": {
+                    "total": 0,
+                    "days": 14
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/options/{underlying}/by-strike": {
+      "get": {
+        "summary": "Strike-level aggregates: OI + volume + avg IV per strike.",
+        "description": "One row per strike rolling up every listed expiry (or a single expiry when `?expiry` is supplied). Powers the /options/by-strike dashboard.",
+        "operationId": "optionsByStrike",
+        "tags": [
+          "Options"
+        ],
+        "parameters": [
+          {
+            "name": "underlying",
+            "in": "path",
+            "required": true,
+            "description": "BTC or ETH.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "BTC",
+                "ETH"
+              ]
+            }
+          },
+          {
+            "name": "expiry",
+            "in": "query",
+            "required": false,
+            "description": "Narrow aggregation to a single expiry.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "underlying": "BTC",
+                    "expiry": null,
+                    "rows": []
+                  },
+                  "meta": {
+                    "total": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/options/{underlying}/by-expiry": {
+      "get": {
+        "summary": "Expiry-level aggregates — term structure of OI, volume, max pain.",
+        "description": "One row per listed expiry with OI / volume / put-call OI / max-pain strike / strike count. Chronological. Powers the /options/by-expiry dashboard.",
+        "operationId": "optionsByExpiry",
+        "tags": [
+          "Options"
+        ],
+        "parameters": [
+          {
+            "name": "underlying",
+            "in": "path",
+            "required": true,
+            "description": "BTC or ETH.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "BTC",
+                "ETH"
+              ]
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "underlying": "BTC",
+                    "rows": []
+                  },
+                  "meta": {
+                    "total": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/options/{underlying}/oi": {
+      "get": {
+        "summary": "Aggregate open interest — totals + per-exchange breakdown.",
+        "description": "Deribit is the only options source wired today — expect a single row in `byExchange`. Scaffolded for future OKX / Bybit / Binance options ingestion.",
+        "operationId": "optionsOi",
+        "tags": [
+          "Options"
+        ],
+        "parameters": [
+          {
+            "name": "underlying",
+            "in": "path",
+            "required": true,
+            "description": "BTC or ETH.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "BTC",
+                "ETH"
+              ]
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "underlying": "BTC",
+                    "totalOi": 220000,
+                    "callOi": 120000,
+                    "putOi": 100000,
+                    "putCallOi": 0.83,
+                    "asOf": 1744834800000,
+                    "byExchange": []
+                  },
+                  "meta": {
+                    "total": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/options/{underlying}/volume": {
+      "get": {
+        "summary": "Aggregate 24h volume — totals + per-strike breakdown.",
+        "description": "Latest-snapshot 24h volume rolled up across expiries, plus a per-strike breakdown. Narrow to a single expiry with `?expiry`.",
+        "operationId": "optionsVolume",
+        "tags": [
+          "Options"
+        ],
+        "parameters": [
+          {
+            "name": "underlying",
+            "in": "path",
+            "required": true,
+            "description": "BTC or ETH.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "BTC",
+                "ETH"
+              ]
+            }
+          },
+          {
+            "name": "expiry",
+            "in": "query",
+            "required": false,
+            "description": "Restrict per-strike breakdown to one expiry.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "underlying": "BTC",
+                    "expiry": null,
+                    "totalVol": 89400,
+                    "callVol": 52000,
+                    "putVol": 37400,
+                    "putCallVol": 0.72,
+                    "asOf": 1744834800000,
+                    "byStrike": []
+                  },
+                  "meta": {
+                    "total": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/options/{underlying}/expiries": {
+      "get": {
+        "summary": "Distinct expiry list at the latest snapshot with strike counts.",
+        "description": "Chronologically ordered. Each entry carries the Deribit label (`DDMMMYY`), the parsed ms timestamp (settles at 08:00 UTC), and the count of strikes currently listed under it.",
+        "operationId": "optionsExpiries",
+        "tags": [
+          "Options"
+        ],
+        "parameters": [
+          {
+            "name": "underlying",
+            "in": "path",
+            "required": true,
+            "description": "BTC or ETH.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "BTC",
+                "ETH"
+              ]
+            }
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "underlying": "BTC",
+                    "expiries": []
+                  },
+                  "meta": {
+                    "total": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "anonymous",
+        "x-rate-limit-rpm": 10
+      }
+    },
+    "/api/v1/options/{underlying}/term-structure": {
+      "get": {
+        "summary": "ATM implied volatility per expiry — the term-structure curve.",
+        "description": "ATM is resolved per expiry as the strike nearest to the latest snapshot's underlying price. Upward slope (contango) = calm spot / uncertain future; downward (backwardation) = near-term stress expected to fade.",
+        "operationId": "optionsTermStructure",
+        "tags": [
+          "Options"
+        ],
+        "parameters": [
+          {
+            "name": "underlying",
+            "in": "path",
+            "required": true,
+            "description": "BTC or ETH.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "BTC",
+                "ETH"
+              ]
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "underlying": "BTC",
+                    "asOf": 1744834800000,
+                    "underlyingPrice": 63150,
+                    "points": []
+                  },
+                  "meta": {
+                    "total": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/on-chain/{asset}": {
+      "get": {
+        "summary": "CoinMetrics-sourced network metrics — realized cap, active addresses, NVT, MVRV, and more.",
+        "description": "When `metric` is omitted you get a summary row for every metric we've ingested for this asset — the latest timestamp, latest value, and source. Pass a specific `metric` and you get a daily time series. Use summary mode on a dashboard to populate many small widgets with one HTTP call; use series mode to chart one metric deeply.",
+        "operationId": "onChainAsset",
+        "tags": [
+          "On-chain"
+        ],
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "path",
+            "required": true,
+            "description": "Short alphabetic asset code. 2–8 letters, uppercase on the wire.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "metric",
+            "in": "query",
+            "required": false,
+            "description": "Metric key (e.g. `realized_cap`, `active_addresses`). Omit for a summary of all metrics.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "History window for series mode. Max 730 (2 years). Ignored in summary mode.",
+            "schema": {
+              "type": "number",
+              "default": 365
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "asset": "BTC",
+                    "metric": "realized_cap",
+                    "days": 180,
+                    "points": [
+                      {
+                        "ts": 1728950400000,
+                        "value": 580123450000
+                      },
+                      {
+                        "ts": 1729036800000,
+                        "value": 581002110000
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 2,
+                    "days": 180
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/on-chain/{asset}/metric/{metric}": {
+      "get": {
+        "summary": "Edge-cacheable variant of /on-chain/{asset} series mode — metric in the path.",
+        "description": "The 'ergonomic' variant of `/api/v1/on-chain/{asset}?metric=…`. Putting the metric in the path makes this trivially cacheable at the edge (no varying query string to normalise) and yields a cleaner URL for doc / changelog embedding. Body shape is 1:1 with the query-based route's series-mode response. Empty series is a valid 200 for a metric we haven't ingested for this asset.",
+        "operationId": "onChainMetric",
+        "tags": [
+          "On-chain"
+        ],
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "path",
+            "required": true,
+            "description": "Short alphabetic asset code.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "metric",
+            "in": "path",
+            "required": true,
+            "description": "CoinMetrics metric name (e.g. `CapMrktCurUSD`, `NVTAdj`, `AdrActCnt`, `HashRate`). Case-sensitive.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "History window. Max 730.",
+            "schema": {
+              "type": "number",
+              "default": 365
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "asset": "BTC",
+                    "metric": "CapMrktCurUSD",
+                    "days": 90,
+                    "points": [
+                      {
+                        "ts": 1737849600000,
+                        "value": 1240000000000
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1,
+                    "days": 90
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/on-chain/{asset}/metrics/list": {
+      "get": {
+        "summary": "Directory of metrics ingested for this asset — for populating chart dropdowns.",
+        "description": "A thin wrapper over `/api/v1/on-chain/{asset}` summary mode that trades the latest VALUE for a minimal directory-style response. Clients use it to build 'what can I chart for this asset?' dropdowns without pulling every metric's current reading. Empty array is a valid 200 for assets we haven't ingested yet.",
+        "operationId": "onChainMetricsList",
+        "tags": [
+          "On-chain"
+        ],
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "path",
+            "required": true,
+            "description": "Short alphabetic asset code.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "asset": "BTC",
+                    "metrics": [
+                      {
+                        "metricName": "CapMrktCurUSD",
+                        "latestTs": 1744761600000,
+                        "source": "coinmetrics"
+                      },
+                      {
+                        "metricName": "AdrActCnt",
+                        "latestTs": 1744761600000,
+                        "source": "coinmetrics"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 2
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/on-chain/{asset}/active-addresses": {
+      "get": {
+        "summary": "Daily unique active addresses (sender or receiver) — CoinMetrics `AdrActCnt`.",
+        "description": "Count of unique addresses that appeared as either sender or receiver in the 24h window. A clean proxy for on-chain usage. Available for every asset the CoinMetrics poller covers; empty series is a valid 200 for anything else.",
+        "operationId": "onChainActiveAddresses",
+        "tags": [
+          "On-chain"
+        ],
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "path",
+            "required": true,
+            "description": "Short alphabetic asset code.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "History window. Max 730.",
+            "schema": {
+              "type": "number",
+              "default": 365
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "asset": "BTC",
+                    "days": 90,
+                    "metric": "AdrActCnt",
+                    "points": [
+                      {
+                        "ts": 1744761600000,
+                        "value": 905210
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1,
+                    "days": 90
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/on-chain/{asset}/hashrate": {
+      "get": {
+        "summary": "Daily network hashrate for proof-of-work chains — BTC only.",
+        "description": "Values are in TH/s (terahashes per second), CoinMetrics native unit. BTC only — ETH has been PoS since The Merge (2022-09-15) so `HashRate` for ETH is a zeroed-out legacy series. Any non-BTC asset returns 404 `UNSUPPORTED_ASSET` so clients don't accidentally chart a flat zero as real data.",
+        "operationId": "onChainHashrate",
+        "tags": [
+          "On-chain"
+        ],
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "path",
+            "required": true,
+            "description": "BTC only.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "BTC"
+              ]
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "History window. Max 730.",
+            "schema": {
+              "type": "number",
+              "default": 365
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "asset": "BTC",
+                    "days": 180,
+                    "metric": "HashRate",
+                    "points": [
+                      {
+                        "ts": 1744761600000,
+                        "value": 681500000
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1,
+                    "days": 180,
+                    "unit": "TH/s"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/on-chain/{asset}/tx-count": {
+      "get": {
+        "summary": "Daily settled transaction count — CoinMetrics `TxCnt`.",
+        "description": "Wraps the CoinMetrics `TxCnt` metric — daily settled transaction count. Good baseline for network activity; combine with `/active-addresses` for an active-user-per-tx ratio.",
+        "operationId": "onChainTxCount",
+        "tags": [
+          "On-chain"
+        ],
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "path",
+            "required": true,
+            "description": "Short alphabetic asset code.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "History window. Max 730.",
+            "schema": {
+              "type": "number",
+              "default": 365
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "asset": "BTC",
+                    "days": 30,
+                    "metric": "TxCnt",
+                    "points": [
+                      {
+                        "ts": 1744761600000,
+                        "value": 385210
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1,
+                    "days": 30
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/on-chain/{asset}/mvrv": {
+      "get": {
+        "summary": "Derived MVRV (MarketCap / RealizedCap) — daily series without a Pro tier.",
+        "description": "Derived on the fly from the two free CoinMetrics primitives (`CapMrktCurUSD`, `CapRealUSD`) — we do NOT require the direct `CapMVRVCur` metric, which is Pro-gated on the Community tier. Only BTC / ETH have sufficient coverage; other assets return an empty series rather than a 404.",
+        "operationId": "onChainMvrv",
+        "tags": [
+          "On-chain"
+        ],
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "path",
+            "required": true,
+            "description": "Short alphabetic asset code (BTC / ETH recommended).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "History window. Max 730.",
+            "schema": {
+              "type": "number",
+              "default": 365
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "asset": "BTC",
+                    "days": 180,
+                    "points": [
+                      {
+                        "ts": 1744761600000,
+                        "value": 2.18
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1,
+                    "days": 180,
+                    "derivation": "CapMrktCurUSD / CapRealUSD"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/on-chain/{asset}/nvt": {
+      "get": {
+        "summary": "Kalichkin-adjusted NVT — CoinMetrics `NVTAdj`.",
+        "description": "Thin wrapper around the CoinMetrics `NVTAdj` (Kalichkin-adjusted NVT) metric. We deliberately do NOT synthesise NVT locally from MarketCap and TxVolume — the adjustment smoothing is non-trivial and we'd drift from the value the cycle dashboard consumes. Empty series is a valid 200 for assets without an NVT feed.",
+        "operationId": "onChainNvt",
+        "tags": [
+          "On-chain"
+        ],
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "path",
+            "required": true,
+            "description": "Short alphabetic asset code.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "History window. Max 730.",
+            "schema": {
+              "type": "number",
+              "default": 365
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "asset": "BTC",
+                    "days": 365,
+                    "metric": "NVTAdj",
+                    "points": [
+                      {
+                        "ts": 1744761600000,
+                        "value": 84.2
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1,
+                    "days": 365
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/etf/bitcoin": {
+      "get": {
+        "summary": "Daily spot Bitcoin ETF flows, cumulative AUM, rolling 7-day flow, and issuer breakdown.",
+        "description": "Spot BTC ETFs (IBIT, FBTC, BITB, etc.) became the biggest new buyer of bitcoin in 2024 — this is the daily flow telemetry. You get per-ticker flows per day, the cumulative AUM total, the rolling 7-day net flow (the headline number traders cite), and extremes: biggest inflow and outflow day in the window.",
+        "operationId": "etfBitcoin",
+        "tags": [
+          "ETFs"
+        ],
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Trailing window of daily flow rows. Max 365.",
+            "schema": {
+              "type": "number",
+              "default": 30
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "flows": [
+                      {
+                        "date": "2026-04-17",
+                        "tickerFlows": {
+                          "IBIT": 112.4,
+                          "FBTC": 64.2,
+                          "BITB": 18.5
+                        },
+                        "total": 195.1
+                      }
+                    ],
+                    "cumulative": 43210.55,
+                    "rolling7d": 920.12,
+                    "biggestInflow": {
+                      "date": "2026-03-05",
+                      "totalUsdM": 1045.3
+                    },
+                    "biggestOutflow": {
+                      "date": "2026-02-19",
+                      "totalUsdM": -385.7
+                    },
+                    "topIssuers": [
+                      {
+                        "ticker": "IBIT",
+                        "cumulativeUsdM": 24100,
+                        "share": 0.56
+                      },
+                      {
+                        "ticker": "FBTC",
+                        "cumulativeUsdM": 11200,
+                        "share": 0.26
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1,
+                    "days": 30
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/etf/ethereum": {
+      "get": {
+        "summary": "Daily spot Ethereum ETF flows — mirrors the shape of the Bitcoin endpoint.",
+        "description": "Same shape as `/api/v1/etf/bitcoin`, but for the spot ETH ETF cohort (ETHA, FETH, ETHW, ETHV, etc.). Flows have been noisier than BTC — mixing with staking-yield ETFs makes the aggregate interpretation less clean. Use this endpoint for flow-direction headlines; cross-check against the per-ticker breakdown before trading it.",
+        "operationId": "etfEthereum",
+        "tags": [
+          "ETFs"
+        ],
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Trailing window of daily flow rows. Max 365.",
+            "schema": {
+              "type": "number",
+              "default": 30
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "flows": [
+                      {
+                        "date": "2026-04-17",
+                        "tickerFlows": {
+                          "ETHA": 22.1,
+                          "FETH": 18.4,
+                          "ETHV": 5.2
+                        },
+                        "total": 45.7
+                      }
+                    ],
+                    "cumulative": 2810.33,
+                    "rolling7d": 88.12,
+                    "biggestInflow": {
+                      "date": "2026-03-21",
+                      "totalUsdM": 215.8
+                    },
+                    "biggestOutflow": {
+                      "date": "2026-02-11",
+                      "totalUsdM": -120
+                    },
+                    "topIssuers": [
+                      {
+                        "ticker": "ETHA",
+                        "cumulativeUsdM": 1400,
+                        "share": 0.5
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1,
+                    "days": 30
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/etf/{asset}": {
+      "get": {
+        "summary": "Unified ETF summary — accepts bitcoin|ethereum|btc|eth in one route.",
+        "description": "Mirrors the shape of `/api/v1/etf/bitcoin` and `/api/v1/etf/ethereum` but takes the asset as a path segment, so a single client implementation can serve both. Case-insensitive — `bitcoin`, `BTC`, `btc`, and `Bitcoin` all resolve the same. The legacy static routes remain for backwards compatibility; prefer this dynamic route for new integrations.",
+        "operationId": "etfAsset",
+        "tags": [
+          "ETFs"
+        ],
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "path",
+            "required": true,
+            "description": "Which ETF cohort to return. Canonicalised to BTC or ETH server-side.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "bitcoin",
+                "ethereum",
+                "btc",
+                "eth"
+              ]
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Trailing window of daily flow rows. Max 365.",
+            "schema": {
+              "type": "number",
+              "default": 30
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "asset": "BTC",
+                    "flows": [
+                      {
+                        "date": "2026-04-17",
+                        "tickerFlows": {
+                          "IBIT": 112.4,
+                          "FBTC": 64.2
+                        },
+                        "total": 176.6
+                      }
+                    ],
+                    "cumulative": 43210.55,
+                    "rolling7d": 920.12,
+                    "biggestInflow": {
+                      "date": "2026-03-05",
+                      "totalUsdM": 1045.3
+                    },
+                    "biggestOutflow": {
+                      "date": "2026-02-19",
+                      "totalUsdM": -385.7
+                    },
+                    "topIssuers": [
+                      {
+                        "ticker": "IBIT",
+                        "cumulativeUsdM": 24100,
+                        "share": 0.56
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1,
+                    "days": 30,
+                    "asset": "BTC"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/etf/{asset}/{ticker}": {
+      "get": {
+        "summary": "Single-ticker daily flow history for one spot ETF.",
+        "description": "Drill into a single ETF product (IBIT, FBTC, ETHA …) and pull its daily flow series. Useful for issuer-vs-issuer charts or for tracking whether a specific fund is driving the headline number. Empty `points` is a valid 200, not a 404 — ingest lag for a new listing shouldn't break clients.",
+        "operationId": "etfAssetTicker",
+        "tags": [
+          "ETFs"
+        ],
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "path",
+            "required": true,
+            "description": "Parent asset. Canonicalised to BTC or ETH.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "bitcoin",
+                "ethereum",
+                "btc",
+                "eth"
+              ]
+            }
+          },
+          {
+            "name": "ticker",
+            "in": "path",
+            "required": true,
+            "description": "3-8 char uppercase alphanumeric ticker. Case-insensitive on input.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Trailing window. Max 1095 (3 years).",
+            "schema": {
+              "type": "number",
+              "default": 365
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "asset": "BTC",
+                    "ticker": "IBIT",
+                    "days": 90,
+                    "points": [
+                      {
+                        "date": "2026-01-18",
+                        "flowUsdM": 112.4
+                      },
+                      {
+                        "date": "2026-01-19",
+                        "flowUsdM": 88.1
+                      }
+                    ],
+                    "cumulativeUsdM": 24100
+                  },
+                  "meta": {
+                    "total": 2,
+                    "days": 90,
+                    "asset": "BTC",
+                    "ticker": "IBIT"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/etf/{asset}/aum": {
+      "get": {
+        "summary": "Cumulative all-time net flow plus issuer-level breakdown for the asset.",
+        "description": "The headline AUM number — sum of every signed daily flow for the asset since ETF inception. Coinglass calls this 'Total Net Inflow' on `/bitcoin-etf`; it's a lower bound on true AUM (it ignores price appreciation of held coins). Paired with the per-issuer cumulative breakdown so you can see who's holding what.",
+        "operationId": "etfAssetAum",
+        "tags": [
+          "ETFs"
+        ],
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "path",
+            "required": true,
+            "description": "bitcoin | ethereum | btc | eth",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "bitcoin",
+                "ethereum",
+                "btc",
+                "eth"
+              ]
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "asset": "BTC",
+                    "cumulativeUsdM": 43210.55,
+                    "issuers": [
+                      {
+                        "ticker": "IBIT",
+                        "cumulativeUsdM": 24100,
+                        "share": 0.56
+                      },
+                      {
+                        "ticker": "FBTC",
+                        "cumulativeUsdM": 11200,
+                        "share": 0.26
+                      },
+                      {
+                        "ticker": "GBTC",
+                        "cumulativeUsdM": -18000,
+                        "share": 0.19
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 3,
+                    "asset": "BTC"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/etf/{asset}/biggest-flows": {
+      "get": {
+        "summary": "Top-N biggest inflow and outflow days for the asset.",
+        "description": "Historical extremes — the days that defined each ETF era. Inflows are sorted biggest→smallest; outflows most-negative→least-negative. Days that don't qualify (pure inflow-only or outflow-only history) drop out rather than showing as zero.",
+        "operationId": "etfAssetBiggestFlows",
+        "tags": [
+          "ETFs"
+        ],
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "path",
+            "required": true,
+            "description": "bitcoin | ethereum | btc | eth",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "bitcoin",
+                "ethereum",
+                "btc",
+                "eth"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Top-N bucket size for each side. Max 50.",
+            "schema": {
+              "type": "number",
+              "default": 10
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "asset": "BTC",
+                    "inflows": [
+                      {
+                        "date": "2026-03-05",
+                        "totalUsdM": 1045.3
+                      },
+                      {
+                        "date": "2026-02-14",
+                        "totalUsdM": 780.1
+                      }
+                    ],
+                    "outflows": [
+                      {
+                        "date": "2026-02-19",
+                        "totalUsdM": -385.7
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 3,
+                    "limit": 5,
+                    "asset": "BTC"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/etf/{asset}/tickers": {
+      "get": {
+        "summary": "Distinct tickers tracked for the asset plus the canonical order.",
+        "description": "`tickers` is a de-duplicated, alpha-sorted list sourced from the `etf_flow` table — use this to populate dropdowns or validate `:ticker` path params before calling the per-ticker route. `canonicalOrder` is the curated chart stacking order we use internally (oldest launches bottom-up).",
+        "operationId": "etfAssetTickers",
+        "tags": [
+          "ETFs"
+        ],
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "path",
+            "required": true,
+            "description": "bitcoin | ethereum | btc | eth",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "bitcoin",
+                "ethereum",
+                "btc",
+                "eth"
+              ]
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "asset": "BTC",
+                    "tickers": [
+                      "ARKB",
+                      "BITB",
+                      "BITI",
+                      "BITW",
+                      "BRRR",
+                      "BTC",
+                      "BTCO",
+                      "BTCW",
+                      "DEFI",
+                      "EZBC",
+                      "FBTC",
+                      "GBTC",
+                      "HODL",
+                      "IBIT"
+                    ],
+                    "canonicalOrder": [
+                      "GBTC",
+                      "IBIT",
+                      "FBTC",
+                      "BITB",
+                      "ARKB",
+                      "BTCO",
+                      "EZBC",
+                      "BRRR",
+                      "HODL",
+                      "BTCW",
+                      "BTC",
+                      "DEFI",
+                      "BITW",
+                      "BITI"
+                    ]
+                  },
+                  "meta": {
+                    "total": 14,
+                    "asset": "BTC"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/etf/{asset}/cumulative": {
+      "get": {
+        "summary": "Cumulative running-sum flow time series for the asset.",
+        "description": "The 'up and to the right' curve — each point is the running total of daily net flow at end-of-day. Good for plotting AUM accumulation against price.",
+        "operationId": "etfAssetCumulative",
+        "tags": [
+          "ETFs"
+        ],
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "path",
+            "required": true,
+            "description": "bitcoin | ethereum | btc | eth",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "bitcoin",
+                "ethereum",
+                "btc",
+                "eth"
+              ]
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Trailing window. Max 365.",
+            "schema": {
+              "type": "number",
+              "default": 365
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "asset": "BTC",
+                    "days": 180,
+                    "points": [
+                      {
+                        "date": "2025-10-19",
+                        "cumulativeUsdM": 38000
+                      },
+                      {
+                        "date": "2025-10-20",
+                        "cumulativeUsdM": 38112.4
+                      },
+                      {
+                        "date": "2025-10-21",
+                        "cumulativeUsdM": 38200.5
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 3,
+                    "days": 180,
+                    "asset": "BTC"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/etf/{asset}/daily": {
+      "get": {
+        "summary": "Daily per-ticker flow breakdown, newest first.",
+        "description": "Same `flows` array you see embedded in the summary route, returned as a first-class resource so clients that only need the time series can skip the rest of the envelope.",
+        "operationId": "etfAssetDaily",
+        "tags": [
+          "ETFs"
+        ],
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "path",
+            "required": true,
+            "description": "bitcoin | ethereum | btc | eth",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "bitcoin",
+                "ethereum",
+                "btc",
+                "eth"
+              ]
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Trailing window. Max 365.",
+            "schema": {
+              "type": "number",
+              "default": 30
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "asset": "ETH",
+                    "days": 7,
+                    "flows": [
+                      {
+                        "date": "2026-04-17",
+                        "tickerFlows": {
+                          "ETHA": 22.1,
+                          "FETH": 18.4
+                        },
+                        "total": 40.5
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1,
+                    "days": 7,
+                    "asset": "ETH"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/etf/hk": {
+      "get": {
+        "summary": "Hong Kong spot BTC/ETH ETFs — canonical shape with a data-status flag.",
+        "description": "Hong Kong spot ETFs (CSOP, ChinaAMC, Harvest, Bosera) are the Asia-session counterpart to the US funds. Ingestion is NOT live yet — the schema already carries a `region='HK'` column on `etf_flow`, so rows will flow through this endpoint automatically once the adapter ships. Until then `meta.dataStatus = 'not-yet-ingested'` so dashboards can render a friendly placeholder.",
+        "operationId": "etfHk",
+        "tags": [
+          "ETFs"
+        ],
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Trailing window. Max 365. Ignored when no rows exist.",
+            "schema": {
+              "type": "number",
+              "default": 30
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "region": "HK",
+                    "flows": [],
+                    "cumulative": 0
+                  },
+                  "meta": {
+                    "total": 0,
+                    "days": 30,
+                    "dataStatus": "not-yet-ingested"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/etf/grayscale": {
+      "get": {
+        "summary": "Grayscale product family rollup (GBTC, ETHE, mini trusts).",
+        "description": "The Grayscale family has a unique shape — GBTC bled out tens of billions post-ETF-conversion, the mini trusts (BTC, ETH) launched from scratch, and ETHE is mid-reshuffle. This endpoint pulls all four from the shared `etf_flow` table so the numbers reconcile 1:1 with the per-asset routes.",
+        "operationId": "etfGrayscale",
+        "tags": [
+          "ETFs"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "family": "grayscale",
+                    "tickers": [
+                      "GBTC",
+                      "BTC",
+                      "ETHE",
+                      "ETH"
+                    ],
+                    "cumulativeUsdM": -14850.2,
+                    "holdings": [
+                      {
+                        "ticker": "BTC",
+                        "asset": "BTC",
+                        "cumulativeUsdM": 1210.5,
+                        "lastDate": "2026-04-17"
+                      },
+                      {
+                        "ticker": "ETH",
+                        "asset": "ETH",
+                        "cumulativeUsdM": 140.8,
+                        "lastDate": "2026-04-17"
+                      },
+                      {
+                        "ticker": "ETHE",
+                        "asset": "ETH",
+                        "cumulativeUsdM": -820.4,
+                        "lastDate": "2026-04-17"
+                      },
+                      {
+                        "ticker": "GBTC",
+                        "asset": "BTC",
+                        "cumulativeUsdM": -15381.1,
+                        "lastDate": "2026-04-17"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 4
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/etf/corporate-treasury": {
+      "get": {
+        "summary": "Corporate bitcoin treasuries (MSTR + peers) — canonical shape, ingestion pending.",
+        "description": "Public companies holding bitcoin on their balance sheet (MicroStrategy, Tesla, Marathon, Block, …). Ingestion requires 10-Q / 8-K parsing and/or a BitcoinTreasuries feed — not live yet. The wire shape is stable so dashboards can be built today; `meta.dataStatus = 'not-yet-ingested'` tells clients to render a placeholder.",
+        "operationId": "etfCorporateTreasury",
+        "tags": [
+          "ETFs"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "companies": [],
+                    "totalBtc": 0,
+                    "totalUsd": 0
+                  },
+                  "meta": {
+                    "total": 0,
+                    "dataStatus": "not-yet-ingested"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/etf/corporate-treasury/{ticker}": {
+      "get": {
+        "summary": "Single-company bitcoin treasury history.",
+        "description": "Per-company drill-down: current holdings, average cost basis, and transaction history. Same ingestion status as the list route — stable shape, `meta.dataStatus` signals readiness.",
+        "operationId": "etfCorporateTreasuryTicker",
+        "tags": [
+          "ETFs"
+        ],
+        "parameters": [
+          {
+            "name": "ticker",
+            "in": "path",
+            "required": true,
+            "description": "3-8 char alphanumeric stock ticker (MSTR, TSLA, MARA…).",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "ticker": "MSTR",
+                    "name": null,
+                    "btcHeld": 0,
+                    "usdValue": 0,
+                    "avgCostBasis": null,
+                    "lastUpdated": null,
+                    "transactions": []
+                  },
+                  "meta": {
+                    "total": 0,
+                    "ticker": "MSTR",
+                    "dataStatus": "not-yet-ingested"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/etf/summary": {
+      "get": {
+        "summary": "Cross-asset ETF rollup — BTC + ETH + combined in a single call.",
+        "description": "Dashboard-friendly single-call summary. Returns the latest day's flow, rolling 7-day flow, cumulative AUM, and all-time extremes for both BTC and ETH, plus the combined totals. Windows are fixed here — custom time ranges belong on the per-asset routes.",
+        "operationId": "etfSummary",
+        "tags": [
+          "ETFs"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "assets": {
+                      "BTC": {
+                        "latestDate": "2026-04-17",
+                        "latestFlowUsdM": 195.1,
+                        "rolling7dUsdM": 920.12,
+                        "cumulativeUsdM": 43210.55,
+                        "biggestInflow": {
+                          "date": "2026-03-05",
+                          "totalUsdM": 1045.3
+                        },
+                        "biggestOutflow": {
+                          "date": "2026-02-19",
+                          "totalUsdM": -385.7
+                        }
+                      },
+                      "ETH": {
+                        "latestDate": "2026-04-17",
+                        "latestFlowUsdM": 45.7,
+                        "rolling7dUsdM": 88.12,
+                        "cumulativeUsdM": 2810.33,
+                        "biggestInflow": {
+                          "date": "2026-03-21",
+                          "totalUsdM": 215.8
+                        },
+                        "biggestOutflow": {
+                          "date": "2026-02-11",
+                          "totalUsdM": -120
+                        }
+                      }
+                    },
+                    "combined": {
+                      "latestFlowUsdM": 240.8,
+                      "rolling7dUsdM": 1008.24,
+                      "cumulativeUsdM": 46020.88
+                    }
+                  },
+                  "meta": {
+                    "total": 2
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/sentiment/fear-greed": {
+      "get": {
+        "summary": "Crypto Fear & Greed Index — latest reading plus history.",
+        "description": "The classic 0–100 sentiment gauge (0 = extreme fear, 100 = extreme greed). Useful as a contrarian overlay on price charts. Response includes the latest reading and an ordered history series so you don't need a second call to render the chart.",
+        "operationId": "sentimentFearGreed",
+        "tags": [
+          "Sentiment"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "How many history points to return, newest-first internally but returned oldest→newest. Max 1000.",
+            "schema": {
+              "type": "number",
+              "default": 365
+            }
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "latest": {
+                      "ts": 1744761600000,
+                      "value": 62,
+                      "classification": "Greed"
+                    },
+                    "history": [
+                      {
+                        "ts": 1744243200000,
+                        "value": 54,
+                        "classification": "Neutral"
+                      },
+                      {
+                        "ts": 1744329600000,
+                        "value": 58,
+                        "classification": "Greed"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 2,
+                    "limit": 7
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "anonymous",
+        "x-rate-limit-rpm": 10
+      }
+    },
+    "/api/v1/sentiment/list": {
+      "get": {
+        "summary": "Directory of every sentiment index we have stored, with the latest reading for each.",
+        "description": "Discovery endpoint. Returns the set of distinct `index_name` values in the `sentiment_index` table — e.g. `crypto_fear_greed`, `btc_dvol`, future alt-season / social indices — plus the most recent value and classification for each. Use it to build dropdowns or to detect when a new index ingestion goes live.",
+        "operationId": "sentimentList",
+        "tags": [
+          "Sentiment"
+        ],
+        "parameters": [],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "indexes": [
+                      {
+                        "indexName": "crypto_fear_greed",
+                        "source": "alternative.me",
+                        "latestTs": 1744761600000,
+                        "latestValue": 62,
+                        "latestClassification": "Greed"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "anonymous",
+        "x-rate-limit-rpm": 10
+      }
+    },
+    "/api/v1/sentiment/{index}": {
+      "get": {
+        "summary": "Latest reading for a single sentiment index, looked up by name.",
+        "description": "Thin companion to `/sentiment/list`. When you already know the index you want, this returns only the newest sample — cheaper than hitting the history endpoint with `limit=1`. An unknown name resolves to `{ latest: null }` with `meta.unavailable = \"no-data\"` (a 200, not a 404), so the client UX stays uniform.",
+        "operationId": "sentimentIndex",
+        "tags": [
+          "Sentiment"
+        ],
+        "parameters": [
+          {
+            "name": "index",
+            "in": "path",
+            "required": true,
+            "description": "Sentiment index name (e.g. `crypto_fear_greed`). Must match the `index_name` in `sentiment_index`.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "indexName": "crypto_fear_greed",
+                    "source": "alternative.me",
+                    "latest": {
+                      "ts": 1744761600000,
+                      "value": 62,
+                      "classification": "Greed"
+                    }
+                  },
+                  "meta": {
+                    "total": 1
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "anonymous",
+        "x-rate-limit-rpm": 10
+      }
+    },
+    "/api/v1/sentiment/{index}/history": {
+      "get": {
+        "summary": "Historical time series for a named sentiment index, ready for charting.",
+        "description": "Returns up to `limit` datapoints for the requested index. Internally fetched newest-first and flipped to oldest → newest for direct chart consumption — so you don't need to `.reverse()` in the client.",
+        "operationId": "sentimentIndexHistory",
+        "tags": [
+          "Sentiment"
+        ],
+        "parameters": [
+          {
+            "name": "index",
+            "in": "path",
+            "required": true,
+            "description": "Sentiment index name.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max points to return. 1–1000.",
+            "schema": {
+              "type": "number",
+              "default": 365
+            }
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "indexName": "crypto_fear_greed",
+                    "latest": {
+                      "ts": 1744761600000,
+                      "value": 62,
+                      "classification": "Greed"
+                    },
+                    "history": [
+                      {
+                        "ts": 1744243200000,
+                        "value": 54,
+                        "classification": "Neutral"
+                      },
+                      {
+                        "ts": 1744329600000,
+                        "value": 58,
+                        "classification": "Greed"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 2,
+                    "limit": 7
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "anonymous",
+        "x-rate-limit-rpm": 10
+      }
+    },
+    "/api/v1/on-chain/whale-transfers": {
+      "get": {
+        "summary": "Recent large on-chain transfers plus an hourly volume histogram.",
+        "description": "Populates the /on-chain/whales dashboard. Returns the newest `limit` transfers at or above `min_usd` plus an hourly rollup of USD volume for the trailing window. Rows include `fromLabel` / `toLabel` when the sender or recipient is a known exchange wallet. Empty feed returns `meta.unavailable = \"no-data\"` — not a 500.",
+        "operationId": "onChainWhaleTransfers",
+        "tags": [
+          "On-chain"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Rows to return. Max 500.",
+            "schema": {
+              "type": "number",
+              "default": 100
+            }
+          },
+          {
+            "name": "min_usd",
+            "in": "query",
+            "required": false,
+            "description": "Minimum USD value per transfer. Use `1000000` for $1M, `50000000` for $50M.",
+            "schema": {
+              "type": "number",
+              "default": 10000000
+            }
+          },
+          {
+            "name": "hours",
+            "in": "query",
+            "required": false,
+            "description": "Volume-histogram lookback in hours. Max 720 (30 days).",
+            "schema": {
+              "type": "number",
+              "default": 48
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "transfers": [
+                      {
+                        "ts": 1744835000000,
+                        "chain": "ETH",
+                        "symbol": "USDT",
+                        "txHash": "0xabc...",
+                        "fromAddr": "0x28c6...d60",
+                        "toAddr": "0x71660...d3",
+                        "fromLabel": "Binance 14 (hot)",
+                        "toLabel": "Coinbase 1",
+                        "amountBase": 25000000,
+                        "amountUsd": 25000000,
+                        "source": "whale_alert"
+                      }
+                    ],
+                    "volume": [
+                      {
+                        "ts": 1744833600000,
+                        "volumeUsd": 42000000
+                      },
+                      {
+                        "ts": 1744837200000,
+                        "volumeUsd": 18500000
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1,
+                    "limit": 5,
+                    "minUsd": 10000000,
+                    "hours": 48
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "startup",
+        "x-rate-limit-rpm": 80
+      }
+    },
+    "/api/v1/on-chain/stablecoin/supply": {
+      "get": {
+        "summary": "Circulating supply history for every tracked stablecoin in one call.",
+        "description": "Iterates the canonical stablecoin symbol list (USDT, USDC, DAI, TUSD, FDUSD, PYUSD) and returns per-symbol history plus the latest point. Symbols with no ingestion yet come back with `latest: null` and `series: []` — the response shape is stable regardless of coverage.",
+        "operationId": "onChainStablecoinSupply",
+        "tags": [
+          "On-chain"
+        ],
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Trailing window per symbol. Max 730.",
+            "schema": {
+              "type": "number",
+              "default": 180
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "symbols": [
+                      {
+                        "symbol": "USDT",
+                        "latest": {
+                          "ts": 1744761600000,
+                          "circulating": 112500000000
+                        },
+                        "series": [
+                          {
+                            "ts": 1744675200000,
+                            "circulating": 112300000000,
+                            "minted24h": 200000000,
+                            "burned24h": null
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1,
+                    "days": 90
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/on-chain/stablecoin/{symbol}": {
+      "get": {
+        "summary": "Circulating supply history for a single named stablecoin.",
+        "description": "Same shape as `/stablecoin/supply` but scoped to one symbol. Use this when you only need USDT (or USDC, or a newer symbol) and don't want to pay the cost of the full bundle. Unknown symbols return `latest: null, series: []` with `meta.unavailable = \"no-data\"` — still a 200.",
+        "operationId": "onChainStablecoinSymbol",
+        "tags": [
+          "On-chain"
+        ],
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "path",
+            "required": true,
+            "description": "Stablecoin ticker. 2–10 alphanumeric characters, normalised to uppercase.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Trailing window. Max 730.",
+            "schema": {
+              "type": "number",
+              "default": 180
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "symbol": "USDT",
+                    "days": 30,
+                    "latest": {
+                      "ts": 1744761600000,
+                      "circulating": 112500000000
+                    },
+                    "series": [
+                      {
+                        "ts": 1744675200000,
+                        "circulating": 112300000000,
+                        "minted24h": 200000000,
+                        "burned24h": null
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1,
+                    "days": 30
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/on-chain/stablecoin/exchange-reserves": {
+      "get": {
+        "summary": "Latest stablecoin balances held on major exchange wallets.",
+        "description": "Aggregates the shared `exchange_balance` feed down to stablecoin symbols only, de-dups per (exchange, symbol) with the newest snapshot winning, and sorts by USD notional descending. Rising stablecoin reserves on exchanges are a classic 'dry powder' signal for incoming spot buys.",
+        "operationId": "onChainStablecoinExchangeReserves",
+        "tags": [
+          "On-chain"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "reserves": [
+                      {
+                        "exchange": "binance",
+                        "symbol": "USDT",
+                        "ts": 1744834800000,
+                        "balanceUsd": 18400000000
+                      },
+                      {
+                        "exchange": "coinbase",
+                        "symbol": "USDC",
+                        "ts": 1744834800000,
+                        "balanceUsd": 5200000000
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 2
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "startup",
+        "x-rate-limit-rpm": 80
+      }
+    },
+    "/api/v1/indicators/bull-market-peak": {
+      "get": {
+        "summary": "Aggregated cycle-signal dashboard — the JSON mirror of /indicators/bull-market-peak.",
+        "description": "Every bull-market-peak signal computed in one shot: Pi Cycle, MVRV, MVRV Z-Score, 2Y MA Multiplier, Rainbow, NVT, Puell (Pro-gated), RHODL (Pro-gated). Each entry carries both a machine-readable `state` (status + score) and human-friendly `description` / `thresholdLabel` strings. `aggregate` is the dashboard-level heat score; `heat` is in [0, 1].",
+        "operationId": "indicatorsBullMarketPeak",
+        "tags": [
+          "Indicators"
+        ],
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "query",
+            "required": false,
+            "description": "Short alphabetic asset code. Non-BTC assets are accepted but most signals will only fire when we have enough CoinMetrics coverage for them.",
+            "schema": {
+              "type": "string",
+              "default": "BTC"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "asset": "BTC",
+                    "hasAnyData": true,
+                    "hasSufficientData": true,
+                    "aggregate": {
+                      "triggered": 2,
+                      "total": 6,
+                      "heat": 0.41,
+                      "tone": "warming"
+                    },
+                    "signals": [
+                      {
+                        "key": "pi-cycle",
+                        "name": "Pi Cycle Top",
+                        "description": "111-DMA crossing above 2× 350-DMA — historic top marker.",
+                        "thresholdLabel": "111-DMA ≥ 2× 350-DMA",
+                        "unitLabel": "USD",
+                        "state": {
+                          "status": "neutral",
+                          "current": 54210,
+                          "threshold": 68400,
+                          "score": 1
+                        },
+                        "available": true,
+                        "sparkline": []
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 8,
+                    "asset": "BTC"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/indicators/pi-cycle": {
+      "get": {
+        "summary": "Pi Cycle Top signal — 111-DMA vs 2× 350-DMA crossover.",
+        "description": "Isolated Pi Cycle reading extracted from the aggregate cycle dashboard. Fires when the 111-day price SMA crosses above twice the 350-day SMA. Needs at least 350 daily samples — below that the signal is `available: false`.",
+        "operationId": "indicatorsPiCycle",
+        "tags": [
+          "Indicators"
+        ],
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "query",
+            "required": false,
+            "description": "Short alphabetic asset code.",
+            "schema": {
+              "type": "string",
+              "default": "BTC"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "asset": "BTC",
+                    "signal": {
+                      "key": "pi-cycle",
+                      "name": "Pi Cycle Top",
+                      "description": "111-DMA crossing above 2× 350-DMA — historic top marker.",
+                      "thresholdLabel": "111-DMA ≥ 2× 350-DMA",
+                      "unitLabel": "USD",
+                      "state": {
+                        "status": "neutral",
+                        "current": 54210,
+                        "threshold": 68400,
+                        "score": 1
+                      },
+                      "available": true,
+                      "sparkline": [
+                        50120,
+                        50890,
+                        51420
+                      ]
+                    }
+                  },
+                  "meta": {
+                    "total": 1,
+                    "asset": "BTC"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/indicators/rainbow": {
+      "get": {
+        "summary": "Rainbow-band classifier — distance-to-2Y-high proxy.",
+        "description": "Approximation of the Rainbow Chart band using `price / 2Y rolling high` as the axis. A full log-regression fit is overkill for a status readout; this gives a stable band classification and is documented as a deliberate simplification.",
+        "operationId": "indicatorsRainbow",
+        "tags": [
+          "Indicators"
+        ],
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "query",
+            "required": false,
+            "description": "Short alphabetic asset code.",
+            "schema": {
+              "type": "string",
+              "default": "BTC"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "asset": "BTC",
+                    "signal": {
+                      "key": "rainbow",
+                      "name": "Rainbow Band",
+                      "state": {
+                        "status": "neutral",
+                        "current": 0.72,
+                        "threshold": 1,
+                        "score": 1
+                      },
+                      "available": true,
+                      "sparkline": [
+                        60000,
+                        61200,
+                        59800
+                      ]
+                    }
+                  },
+                  "meta": {
+                    "total": 1,
+                    "asset": "BTC"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/indicators/mvrv-z": {
+      "get": {
+        "summary": "MVRV Z-Score — dispersion-normalised market-cap vs realised-cap spread.",
+        "description": "Classic Glassnode-style cycle-top metric: `(MarketCap − RealizedCap) / stddev(MarketCap)`. Threshold 7.0 has flagged every Bitcoin cycle top (2013, 2017, 2021). Requires ≥ 60 daily samples of both cap series.",
+        "operationId": "indicatorsMvrvZ",
+        "tags": [
+          "Indicators"
+        ],
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "query",
+            "required": false,
+            "description": "Short alphabetic asset code.",
+            "schema": {
+              "type": "string",
+              "default": "BTC"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "asset": "BTC",
+                    "signal": {
+                      "key": "mvrv-z",
+                      "name": "MVRV Z-Score",
+                      "state": {
+                        "status": "neutral",
+                        "current": 2.4,
+                        "threshold": 7,
+                        "score": 1
+                      },
+                      "available": true,
+                      "sparkline": [
+                        2.1,
+                        2.3,
+                        2.4
+                      ]
+                    }
+                  },
+                  "meta": {
+                    "total": 1,
+                    "asset": "BTC"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/indicators/puell": {
+      "get": {
+        "summary": "Puell Multiple (miner-revenue cycle signal) — Pro-tier metric.",
+        "description": "Puell Multiple = daily issuance value / 365-day MA of daily issuance value. Requires the `IssTotUSD` primitive, which is Pro-gated on the CoinMetrics Community tier. We return the signal envelope with `available: false` and `meta.unavailable = \"pro-tier\"` so UIs can render a stable 'Pro-only' pill.",
+        "operationId": "indicatorsPuell",
+        "tags": [
+          "Indicators"
+        ],
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "query",
+            "required": false,
+            "description": "Short alphabetic asset code.",
+            "schema": {
+              "type": "string",
+              "default": "BTC"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "asset": "BTC",
+                    "signal": {
+                      "key": "puell",
+                      "name": "Puell Multiple",
+                      "available": false,
+                      "unavailableReason": "pro_metric",
+                      "sparkline": []
+                    }
+                  },
+                  "meta": {
+                    "total": 1,
+                    "asset": "BTC",
+                    "unavailable": "pro-tier"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/indicators/rsi-heatmap": {
+      "get": {
+        "summary": "Per-coin RSI heatmap across the top basket — feed pending.",
+        "description": "Returns per-coin RSI for the top cryptocurrency basket. Blocked on a broader spot-price ingestion feed — the current CoinMetrics `PriceUSD` coverage only extends to BTC and a few majors. Returns an empty `coins` array with `meta.unavailable = \"not-yet-ingested\"` until the feed lands.",
+        "operationId": "indicatorsRsiHeatmap",
+        "tags": [
+          "Indicators"
+        ],
+        "parameters": [
+          {
+            "name": "length",
+            "in": "query",
+            "required": false,
+            "description": "RSI lookback period. 2–50.",
+            "schema": {
+              "type": "number",
+              "default": 14
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "length": 14,
+                    "coins": []
+                  },
+                  "meta": {
+                    "total": 0,
+                    "length": 14,
+                    "unavailable": "not-yet-ingested",
+                    "dataStatus": "not-yet-ingested"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/indicators/altcoin-season": {
+      "get": {
+        "summary": "Altcoin-season index (0–100) — feed pending.",
+        "description": "Share of top-50 altcoins that outperformed BTC over the lookback window, mapped to a 0–100 scale. Above 75 = altcoin season; below 25 = Bitcoin season. Blocked on a top-50 spot-price adapter; for now this stub returns `index: null` with `meta.unavailable = \"not-yet-ingested\"`.",
+        "operationId": "indicatorsAltcoinSeason",
+        "tags": [
+          "Indicators"
+        ],
+        "parameters": [
+          {
+            "name": "lookback",
+            "in": "query",
+            "required": false,
+            "description": "Days over which to compare BTC vs the alt basket. 7–365.",
+            "schema": {
+              "type": "number",
+              "default": 90
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "lookback": 90,
+                    "index": null,
+                    "classification": null,
+                    "asOf": null
+                  },
+                  "meta": {
+                    "total": 0,
+                    "lookback": 90,
+                    "unavailable": "not-yet-ingested",
+                    "dataStatus": "not-yet-ingested"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/macro/m2": {
+      "get": {
+        "summary": "U.S. M2 money supply (FRED `M2SL`) — feed pending.",
+        "description": "Seasonally-adjusted M2 in billions of dollars. The classic 'global liquidity' proxy — rising M2 has a loose, lagged correlation with crypto rallies. Stub returns an empty series with `meta.dataStatus = \"not-yet-ingested\"` until the FRED adapter is wired into ingestion.",
+        "operationId": "macroM2",
+        "tags": [
+          "Macro"
+        ],
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Trailing window. Max 3650 (10 years).",
+            "schema": {
+              "type": "number",
+              "default": 365
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "series": "M2SL",
+                    "source": "fred",
+                    "days": 365,
+                    "latest": null,
+                    "points": []
+                  },
+                  "meta": {
+                    "total": 0,
+                    "days": 365,
+                    "dataStatus": "not-yet-ingested",
+                    "unavailable": "not-yet-ingested"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/macro/dxy": {
+      "get": {
+        "summary": "U.S. dollar broad trade-weighted index (FRED `DTWEXBGS`) — feed pending.",
+        "description": "Dollar strength proxy — we use the FRED broad trade-weighted index rather than ICE's proprietary DXY so the feed stays fully free-tier. Inverse correlation to risk assets is well-documented. Stub returns an empty series with `meta.dataStatus = \"not-yet-ingested\"` until the FRED adapter lands.",
+        "operationId": "macroDxy",
+        "tags": [
+          "Macro"
+        ],
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Trailing window. Max 3650.",
+            "schema": {
+              "type": "number",
+              "default": 365
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "series": "DTWEXBGS",
+                    "source": "fred",
+                    "days": 180,
+                    "latest": null,
+                    "points": []
+                  },
+                  "meta": {
+                    "total": 0,
+                    "days": 180,
+                    "dataStatus": "not-yet-ingested",
+                    "unavailable": "not-yet-ingested"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/macro/gold": {
+      "get": {
+        "summary": "Spot gold — London PM fix (FRED `GOLDPMGBD228NLBM`) — feed pending.",
+        "description": "Gold price in USD per troy ounce, London PM fix. Some traders watch the gold/BTC ratio as a rotation gauge between the oldest and newest store-of-value assets. Stub returns an empty series with `meta.dataStatus = \"not-yet-ingested\"`.",
+        "operationId": "macroGold",
+        "tags": [
+          "Macro"
+        ],
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Trailing window. Max 3650.",
+            "schema": {
+              "type": "number",
+              "default": 365
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "series": "GOLDPMGBD228NLBM",
+                    "source": "fred",
+                    "days": 365,
+                    "latest": null,
+                    "points": []
+                  },
+                  "meta": {
+                    "total": 0,
+                    "days": 365,
+                    "dataStatus": "not-yet-ingested",
+                    "unavailable": "not-yet-ingested"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "hobbyist",
+        "x-rate-limit-rpm": 30
+      }
+    },
+    "/api/v1/hyperliquid/vault/hlp": {
+      "get": {
+        "summary": "Hyperliquid HLP vault snapshot + history (TVL, PnL, APR, followers).",
+        "description": "HLP is Hyperliquid's flagship house vault — the one most retail depositors follow because it absorbs flow from the protocol itself. This endpoint gives you the latest snapshot plus a time series suitable for charting TVL curves or benchmarking APR over the trailing window. We key off the vault name, so a future HLP relaunch will still resolve cleanly.",
+        "operationId": "hyperliquidHlp",
+        "tags": [
+          "Hyperliquid"
+        ],
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "History window. Max 365.",
+            "schema": {
+              "type": "number",
+              "default": 30
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "latest": {
+                      "ts": 1744834800000,
+                      "vaultAddress": "0x1719884eb866cb12b2287399b15f7db5e7d775ea",
+                      "name": "HLP",
+                      "leader": null,
+                      "tvl": 512000000,
+                      "pnlDaily": 120000,
+                      "pnlWeekly": 880000,
+                      "pnlAllTime": 41200000,
+                      "apr": 0.185,
+                      "followers": 28000
+                    },
+                    "history": [
+                      {
+                        "ts": 1744230000000,
+                        "vaultAddress": "0x1719884eb866cb12b2287399b15f7db5e7d775ea",
+                        "name": "HLP",
+                        "leader": null,
+                        "tvl": 501200000,
+                        "pnlDaily": 95000,
+                        "pnlWeekly": 760000,
+                        "pnlAllTime": 40320000,
+                        "apr": 0.178,
+                        "followers": 27650
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1,
+                    "days": 7
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/hyperliquid/leaderboard": {
+      "get": {
+        "summary": "Hyperliquid trader leaderboard snapshot for a given time window.",
+        "description": "Who's making money on Hyperliquid right now? This returns the top N traders for a given window (1d, 7d, 30d, YTD, or all-time), ranked by PnL. Use it to watch smart-money addresses, seed a copy-trading tool, or build a whale-follower UI.",
+        "operationId": "hyperliquidLeaderboard",
+        "tags": [
+          "Hyperliquid"
+        ],
+        "parameters": [
+          {
+            "name": "window",
+            "in": "query",
+            "required": false,
+            "description": "Which leaderboard window.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1d",
+                "7d",
+                "30d",
+                "ytd",
+                "all"
+              ],
+              "default": "1d"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "How many traders to return. Max 200.",
+            "schema": {
+              "type": "number",
+              "default": 50
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "window": "7d",
+                    "ts": 1744834800000,
+                    "traders": [
+                      {
+                        "rank": 1,
+                        "address": "0xabc123...def",
+                        "pnl": 4250000,
+                        "pnlPercent": 0.58,
+                        "volume": 310000000,
+                        "accountValue": 11500000
+                      },
+                      {
+                        "rank": 2,
+                        "address": "0x9f8b...01a",
+                        "pnl": 3110000,
+                        "pnlPercent": 0.41,
+                        "volume": 215000000,
+                        "accountValue": 10200000
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 2,
+                    "window": "7d",
+                    "limit": 10
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/hyperliquid/vaults": {
+      "get": {
+        "summary": "Every Hyperliquid vault we track — newest snapshot per vault address, TVL-sorted.",
+        "description": "Beyond HLP, Hyperliquid has dozens of user-leader vaults with varying strategies. This endpoint lists every vault we've seen, collapsed to its newest snapshot per `vault_address` and sorted by TVL desc. Use it to seed a vault-discovery UI or monitor TVL migration between vaults.",
+        "operationId": "hyperliquidVaults",
+        "tags": [
+          "Hyperliquid"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max vaults to return. Max 500.",
+            "schema": {
+              "type": "number",
+              "default": 100
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "vaults": [
+                      {
+                        "ts": 1744834800000,
+                        "vaultAddress": "0xdfc24b077bc1425ad1dea75bcb6f8158e10df303",
+                        "name": "HLP",
+                        "leader": null,
+                        "tvl": 512000000,
+                        "pnlDaily": 120000,
+                        "pnlWeekly": 880000,
+                        "pnlAllTime": 41200000,
+                        "apr": 0.185,
+                        "followers": 28000
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1,
+                    "limit": 10
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/hyperliquid/vault/{address}": {
+      "get": {
+        "summary": "Latest snapshot + trailing history for a single Hyperliquid vault address.",
+        "description": "Same shape as `/vault/hlp` but resolves any vault — handy for drilling into leader vaults or comparing a secondary vault's APR curve against HLP.",
+        "operationId": "hyperliquidVaultAddress",
+        "tags": [
+          "Hyperliquid"
+        ],
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "description": "0x-prefixed 40-char hex address. Case-insensitive on input.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Trailing window for the history series. Max 365.",
+            "schema": {
+              "type": "number",
+              "default": 30
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "address": "0xdfc24b077bc1425ad1dea75bcb6f8158e10df303",
+                    "latest": {
+                      "tvl": 512000000,
+                      "apr": 0.185,
+                      "pnlWeekly": 880000,
+                      "ts": 1744834800000
+                    },
+                    "history": []
+                  },
+                  "meta": {
+                    "total": 0,
+                    "days": 7
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/hyperliquid/vault/hlp/history": {
+      "get": {
+        "summary": "HLP deep-dive bundle — TVL, PnL (daily + weekly), and APR series over N days.",
+        "description": "Three named time series for the HLP vault. Backs the `/hyperliquid/hlp` deep-dive page; integrators can fetch this once and avoid three parallel round-trips.",
+        "operationId": "hyperliquidHlpHistory",
+        "tags": [
+          "Hyperliquid"
+        ],
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Trailing window. Max 365.",
+            "schema": {
+              "type": "number",
+              "default": 30
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "latest": {
+                      "tvl": 512000000,
+                      "apr": 0.185,
+                      "ts": 1744834800000
+                    },
+                    "tvl": [
+                      {
+                        "ts": 1744230000000,
+                        "tvlUsd": 501200000
+                      }
+                    ],
+                    "pnl": [
+                      {
+                        "ts": 1744230000000,
+                        "pnlDaily": 95000,
+                        "pnlWeekly": 760000
+                      }
+                    ],
+                    "apr": [
+                      {
+                        "ts": 1744230000000,
+                        "apr": 0.178
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 3,
+                    "days": 30,
+                    "tvlPoints": 1,
+                    "pnlPoints": 1,
+                    "aprPoints": 1
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/hyperliquid/leaderboard/{window}": {
+      "get": {
+        "summary": "Path-param flavour of the leaderboard endpoint.",
+        "description": "Identical body shape to `/hyperliquid/leaderboard?window=…` — this variant accepts the window as a path segment so callers can bookmark or nest it behind a CDN rewrite.",
+        "operationId": "hyperliquidLeaderboardWindow",
+        "tags": [
+          "Hyperliquid"
+        ],
+        "parameters": [
+          {
+            "name": "window",
+            "in": "path",
+            "required": true,
+            "description": "Leaderboard window.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1d",
+                "7d",
+                "30d",
+                "ytd",
+                "all"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "How many traders to return. Max 200.",
+            "schema": {
+              "type": "number",
+              "default": 50
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "window": "7d",
+                    "ts": 1744834800000,
+                    "traders": []
+                  },
+                  "meta": {
+                    "total": 0,
+                    "window": "7d",
+                    "limit": 10
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/hyperliquid/whale-positions": {
+      "get": {
+        "summary": "Top whale positions by USD size, plus coin/side aggregates in one call.",
+        "description": "Single-call hydration for the `/hyperliquid/whales` page. Returns the top N positions by notional, optionally alongside aggregate rollups (total long/short USD, unique addresses, per-coin breakdown, side totals).",
+        "operationId": "hyperliquidWhalePositions",
+        "tags": [
+          "Hyperliquid"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Rows in the `top` array. Max 500.",
+            "schema": {
+              "type": "number",
+              "default": 50
+            }
+          },
+          {
+            "name": "includeAggs",
+            "in": "query",
+            "required": false,
+            "description": "Set to `false` to skip aggregate computation.",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "top": [
+                      {
+                        "ts": 1744834800000,
+                        "address": "0xabc...def",
+                        "coin": "BTC",
+                        "side": "long",
+                        "sizeUsd": 18250000,
+                        "entryPx": 63100,
+                        "liqPx": 54200,
+                        "unrealizedPnl": 210000,
+                        "marginUsed": 3650000
+                      }
+                    ],
+                    "aggregates": {
+                      "totalPositions": 1,
+                      "totalSizeUsd": 18250000,
+                      "totalLongUsd": 18250000,
+                      "totalShortUsd": 0,
+                      "uniqueAddresses": 1,
+                      "averagePnl": 210000,
+                      "newestTs": 1744834800000,
+                      "byCoin": [],
+                      "bySide": []
+                    }
+                  },
+                  "meta": {
+                    "total": 1,
+                    "limit": 5,
+                    "includeAggs": true
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/hyperliquid/whale-positions/{address}": {
+      "get": {
+        "summary": "All currently-open positions for a single whale address.",
+        "description": "Returns one row per (coin, side) for the given address. Useful for wallet-centric dashboards or to cross-check a leaderboard entry against their actual book.",
+        "operationId": "hyperliquidWhalePositionsAddress",
+        "tags": [
+          "Hyperliquid"
+        ],
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "description": "0x-prefixed 40-char hex address.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "address": "0x...",
+                    "positions": [],
+                    "summary": {
+                      "count": 0,
+                      "totalSizeUsd": 0,
+                      "totalUnrealizedPnl": 0
+                    }
+                  },
+                  "meta": {
+                    "total": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/hyperliquid/whale-positions/by-coin/{coin}": {
+      "get": {
+        "summary": "Every whale position for a single coin, ranked by USD size.",
+        "description": "Drill into who's holding what for a specific coin. Returns the full ordered list plus a small summary (long/short totals, net bias, participant counts).",
+        "operationId": "hyperliquidWhalePositionsByCoin",
+        "tags": [
+          "Hyperliquid"
+        ],
+        "parameters": [
+          {
+            "name": "coin",
+            "in": "path",
+            "required": true,
+            "description": "Base asset code (BTC, ETH, SOL, …).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max positions in the response. Max 500.",
+            "schema": {
+              "type": "number",
+              "default": 100
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "coin": "BTC",
+                    "positions": [],
+                    "summary": {
+                      "count": 0,
+                      "totalSizeUsd": 0,
+                      "longSizeUsd": 0,
+                      "shortSizeUsd": 0,
+                      "netSizeUsd": 0,
+                      "longCount": 0,
+                      "shortCount": 0
+                    }
+                  },
+                  "meta": {
+                    "total": 0,
+                    "coin": "BTC",
+                    "limit": 100
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/hyperliquid/markets": {
+      "get": {
+        "summary": "HL-native markets table — OI, funding, 24h volume, 24h change.",
+        "description": "Every instrument tagged `source='hyperliquid'`, sorted by OI desc and annotated with the full market-row shape used across DEX venues.",
+        "operationId": "hyperliquidMarkets",
+        "tags": [
+          "Hyperliquid"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max markets. Max 1000.",
+            "schema": {
+              "type": "number",
+              "default": 200
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "source": "hyperliquid",
+                    "displayName": "Hyperliquid",
+                    "totalOiUsd": 0,
+                    "totalVolume24hUsd": 0,
+                    "lastTs": null,
+                    "markets": []
+                  },
+                  "meta": {
+                    "total": 0,
+                    "limit": 10
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/hyperliquid/predicted-funding": {
+      "get": {
+        "summary": "Current vs predicted funding rate per HL perp — spot divergences before they print.",
+        "description": "Reads the `funding_rate.predicted_next` column that the HL adapter hydrates on every heartbeat. Sort by the absolute delta between current and predicted to find markets that are about to flip from positive to negative funding (or vice versa).",
+        "operationId": "hyperliquidPredictedFunding",
+        "tags": [
+          "Hyperliquid"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max rows. Max 500.",
+            "schema": {
+              "type": "number",
+              "default": 100
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "description": "Ordering key for the returned list.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "abs",
+                "current",
+                "predicted"
+              ],
+              "default": "abs"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "rates": []
+                  },
+                  "meta": {
+                    "total": 0,
+                    "limit": 10,
+                    "sort": "abs"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/dex/list": {
+      "get": {
+        "summary": "Cross-venue DEX comparison feed — every supported venue with OI, 24h volume, market count, and share %s.",
+        "description": "Backs the `/dex` hub. One row per supported source (Hyperliquid, dYdX v4, GMX v2, Drift, Paradex, Vertex) with the numbers you need to render a venue comparison table plus static metadata (chain label, trade URL, tagline).",
+        "operationId": "dexList",
+        "tags": [
+          "DEX"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "totalOiUsd": 0,
+                    "totalVolume24hUsd": 0,
+                    "totalMarkets": 0,
+                    "liveVenues": 0,
+                    "venues": []
+                  },
+                  "meta": {
+                    "total": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/dex/dydx/markets": {
+      "get": {
+        "summary": "Every dYdX v4 perpetual market.",
+        "description": "Unified DEX market shape for dYdX v4 — OI, funding (8h cadence), 24h volume / trades, 24h mark-price change.",
+        "operationId": "dexDydxMarkets",
+        "tags": [
+          "DEX"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max markets. Max 1000.",
+            "schema": {
+              "type": "number",
+              "default": 200
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "source": "dydx_v4",
+                    "displayName": "dYdX v4",
+                    "markets": []
+                  },
+                  "meta": {
+                    "total": 0,
+                    "limit": 10
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/dex/dydx/markets/{ticker}": {
+      "get": {
+        "summary": "Single dYdX v4 market by canonical symbol or base asset.",
+        "description": "Pass either the full canonical symbol (`BTC-USD-PERP`) or the bare base (`BTC`) — the first match wins, canonical-first.",
+        "operationId": "dexDydxMarketTicker",
+        "tags": [
+          "DEX"
+        ],
+        "parameters": [
+          {
+            "name": "ticker",
+            "in": "path",
+            "required": true,
+            "description": "Canonical symbol or base asset. Case-insensitive.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "source": "dydx_v4",
+                    "displayName": "dYdX v4",
+                    "market": {}
+                  },
+                  "meta": {
+                    "total": 1
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/dex/gmx/markets": {
+      "get": {
+        "summary": "Every GMX v2 market across both chains (Arbitrum + Avalanche).",
+        "description": "For the chain-specific split, use `/dex/gmx/stats?chain=…`. This endpoint returns the combined markets list sorted by OI desc.",
+        "operationId": "dexGmxMarkets",
+        "tags": [
+          "DEX"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max markets. Max 1000.",
+            "schema": {
+              "type": "number",
+              "default": 200
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "source": "gmx_v2",
+                    "markets": []
+                  },
+                  "meta": {
+                    "total": 0,
+                    "limit": 10
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/dex/gmx/stats": {
+      "get": {
+        "summary": "Per-chain GMX v2 breakdown — Arbitrum vs Avalanche.",
+        "description": "Without `?chain`, returns both chains keyed by slug. With `?chain=arb` or `?chain=avax`, returns a single breakdown. Chain split is heuristic today (AVAX-native bases → Avalanche).",
+        "operationId": "dexGmxStats",
+        "tags": [
+          "DEX"
+        ],
+        "parameters": [
+          {
+            "name": "chain",
+            "in": "query",
+            "required": false,
+            "description": "Chain selector. Omit for both chains.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "arb",
+                "avax"
+              ]
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "chain": "arb",
+                    "label": "Arbitrum",
+                    "oiUsd": 0,
+                    "volume24hUsd": 0,
+                    "marketCount": 0,
+                    "markets": [],
+                    "lastTs": null
+                  },
+                  "meta": {
+                    "total": 0,
+                    "chain": "arb"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/dex/drift/markets": {
+      "get": {
+        "summary": "Every Drift (Solana) perpetual market.",
+        "description": "OI, funding (cadence varies by market), 24h volume / trades. Drift runs an orderbook-style DLOB on Solana.",
+        "operationId": "dexDriftMarkets",
+        "tags": [
+          "DEX"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max markets. Max 1000.",
+            "schema": {
+              "type": "number",
+              "default": 200
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "source": "drift",
+                    "markets": []
+                  },
+                  "meta": {
+                    "total": 0,
+                    "limit": 10
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/dex/drift/insurance-fund": {
+      "get": {
+        "summary": "Latest Drift insurance-fund TVL snapshot + 30d delta summary.",
+        "description": "Drift is the only major DEX to publish its on-chain insurance fund balance. This endpoint surfaces the latest reading plus the 30-day USD/%% delta so you don't have to fetch history to render a headline stat.",
+        "operationId": "dexDriftInsuranceFund",
+        "tags": [
+          "DEX"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "latestTvlUsd": null,
+                    "latestTs": null,
+                    "deltaUsd": null,
+                    "deltaPct": null,
+                    "sampleCount": 0
+                  },
+                  "meta": {
+                    "total": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/dex/drift/insurance-fund/history": {
+      "get": {
+        "summary": "Drift insurance-fund TVL time series.",
+        "description": "Full time-series variant of `/insurance-fund` for chart callers.",
+        "operationId": "dexDriftInsuranceFundHistory",
+        "tags": [
+          "DEX"
+        ],
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Trailing window. Max 365.",
+            "schema": {
+              "type": "number",
+              "default": 30
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "points": [],
+                    "latestTvlUsd": null,
+                    "latestTs": null,
+                    "deltaUsd": null,
+                    "deltaPct": null
+                  },
+                  "meta": {
+                    "total": 0,
+                    "days": 30
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/dex/vertex/markets": {
+      "get": {
+        "summary": "Every Vertex (Arbitrum) perpetual market.",
+        "description": "Same DEX market shape as the other venue endpoints. Vertex runs a cross-margin CLOB on Arbitrum.",
+        "operationId": "dexVertexMarkets",
+        "tags": [
+          "DEX"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max markets. Max 1000.",
+            "schema": {
+              "type": "number",
+              "default": 200
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "source": "vertex",
+                    "markets": []
+                  },
+                  "meta": {
+                    "total": 0,
+                    "limit": 10
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/dex/paradex/markets": {
+      "get": {
+        "summary": "Every Paradex (Starknet) perpetual market.",
+        "description": "Same DEX market shape as the other venue endpoints. Paradex runs an off-chain match / on-chain settle model on Starknet.",
+        "operationId": "dexParadexMarkets",
+        "tags": [
+          "DEX"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max markets. Max 1000.",
+            "schema": {
+              "type": "number",
+              "default": 200
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "source": "paradex",
+                    "markets": []
+                  },
+                  "meta": {
+                    "total": 0,
+                    "limit": 10
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "standard",
+        "x-rate-limit-rpm": 300
+      }
+    },
+    "/api/v1/status": {
+      "get": {
+        "summary": "Adapter health + per-table row counts — the public mirror of the internal /status page.",
+        "description": "Call this from your own monitoring before you fire more expensive endpoint calls. The `banner` summarises system health; `adapters` lists every ingest worker with its last heartbeat; `tables` shows ingest volumes per table (so you can spot a stalled feed). Integrators typically check this on a 30-second cron.",
+        "operationId": "status",
+        "tags": [
+          "Meta"
+        ],
+        "parameters": [],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": {
+                    "banner": {
+                      "status": "ok",
+                      "summary": "All 18 adapters healthy.",
+                      "degradedCount": 0
+                    },
+                    "adapters": [
+                      {
+                        "source": "binance_futures",
+                        "status": "ok",
+                        "message": "buffer=42 in=1204 out=1204",
+                        "metrics": {
+                          "buffer": "42",
+                          "in": "1204",
+                          "out": "1204"
+                        },
+                        "lastHeartbeatMs": 1744835110000,
+                        "lastHeartbeatIso": "2026-04-17T04:25:10.000Z",
+                        "secondsSinceHeartbeat": 4
+                      }
+                    ],
+                    "tables": [
+                      {
+                        "table": "liquidation",
+                        "total": 1824321,
+                        "lastHourAdds": 2105
+                      },
+                      {
+                        "table": "open_interest",
+                        "total": 512410,
+                        "lastHourAdds": 360
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "total": 1
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "anonymous",
+        "x-rate-limit-rpm": 10
+      }
+    },
+    "/api/v1/symbols": {
+      "get": {
+        "summary": "Full instrument directory — the table you cache on startup to resolve symbols everywhere else.",
+        "description": "Every other endpoint assumes you already know which canonical symbols exist. This is that source of truth. Pull the full list once at app start, cache it, and diff it on the next cold start. Filter by `base`, `kind`, or prefix `search` to keep responses small during interactive exploration.",
+        "operationId": "symbols",
+        "tags": [
+          "Meta"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Rows per page. Max 5000.",
+            "schema": {
+              "type": "number",
+              "default": 500
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Pagination offset.",
+            "schema": {
+              "type": "number",
+              "default": 0
+            }
+          },
+          {
+            "name": "base",
+            "in": "query",
+            "required": false,
+            "description": "Exact base-asset filter (e.g. `BTC`).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "kind",
+            "in": "query",
+            "required": false,
+            "description": "Instrument family filter.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "perp",
+                "spot",
+                "future",
+                "option"
+              ]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "description": "Case-insensitive prefix search on `canonicalSymbol`. LIKE wildcards are stripped server-side.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiEnvelope"
+                },
+                "example": {
+                  "data": [
+                    {
+                      "id": 12,
+                      "canonicalSymbol": "BTCUSDT",
+                      "base": "BTC",
+                      "quote": "USDT",
+                      "kind": "perp",
+                      "expiry": null,
+                      "strike": null,
+                      "optionType": null
+                    },
+                    {
+                      "id": 14,
+                      "canonicalSymbol": "BTCUSD_PERP",
+                      "base": "BTC",
+                      "quote": "USD",
+                      "kind": "perp",
+                      "expiry": null,
+                      "strike": null,
+                      "optionType": null
+                    }
+                  ],
+                  "meta": {
+                    "total": 2,
+                    "limit": 5,
+                    "offset": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (validation failure). `error.code` = `BAD_PARAM`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Honour `Retry-After`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error (`DB_ERROR` or `INTERNAL_ERROR`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "x-min-tier": "anonymous",
+        "x-rate-limit-rpm": 10
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "cg_live_*",
+        "description": "Pass your API key in the `Authorization: Bearer cg_live_…` header. Create one at /dashboard/api-keys."
+      }
+    },
+    "schemas": {
+      "ApiEnvelope": {
+        "type": "object",
+        "description": "Stable envelope for every response. `data` is null on error; `error` is present only on 4xx/5xx.",
+        "properties": {
+          "data": {
+            "description": "Payload — object, array, or null."
+          },
+          "meta": {
+            "type": "object",
+            "description": "Pagination + per-endpoint extras.",
+            "additionalProperties": true,
+            "properties": {
+              "total": {
+                "type": "integer"
+              },
+              "limit": {
+                "type": "integer"
+              },
+              "offset": {
+                "type": "integer"
+              }
+            }
+          },
+          "error": {
+            "$ref": "#/components/schemas/ApiError"
+          }
+        }
+      },
+      "ApiError": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "description": "Stable `code` values to switch on. `message` is human-readable and may change between releases.",
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": [
+              "BAD_PARAM",
+              "UNKNOWN_UNDERLYING",
+              "UNKNOWN_ASSET",
+              "RATE_LIMITED",
+              "DB_ERROR",
+              "INTERNAL_ERROR"
+            ],
+            "description": "Machine-readable error code."
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable, safe to display."
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "BearerAuth": []
+    }
+  ]
+}


### PR DESCRIPTION
## Add SkynetX

**Spec**: `APIs/skynetx.io/1.0.0/openapi.json`

SkynetX is a real-time crypto derivatives and market-data API — funding rates, open interest, liquidations, ETF flows, options metrics (max pain, IV, Greeks), on-chain signals, and composite indicators (CGDI, CDRI, Fear & Greed).

**Spec coverage**
- 118 operations across 118 paths (every `/api/v1/*` endpoint)
- OpenAPI 3.1.0
- `info.contact.email` = `support@skynetx.io` for ownership verification
- `info.x-logo` set
- Bearer `cg_live_*` security scheme documented
- Shared `$ref` envelope + error schemas

**Live**: https://skynetx.io/openapi.json (kept in sync on every push — can be repointed to reload via apis-dev/collector)

**Human docs**: https://skynetx.io/docs/api
**LLM-friendly**: https://skynetx.io/llms.txt + https://skynetx.io/llms-full.txt

Spec validates clean under `swagger-cli validate` (paths, schemas, refs). Let me know if anything needs adjusting.