### PR TITLE
feat: add VedIntel™ AstroAPI — Vedic astrology, Swiss Ephemeris, 116 endpoints

### DIFF
--- a/APIs/vedintelastroapi.com/v1/openapi.yaml
+++ b/APIs/vedintelastroapi.com/v1/openapi.yaml
@@ -21,3 +21,4 @@ info:
   x-providerName: vedintelastroapi.com
 servers:
   - url: https://vedintelastroapi.com
+paths: {}

--- a/APIs/vedintelastroapi.com/v1/openapi.yaml
+++ b/APIs/vedintelastroapi.com/v1/openapi.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: VedIntel™ AstroAPI
+  version: v1
+  description: >-
+    The most accurate Vedic astrology API — 116 endpoints built on Swiss
+    Ephemeris with accuracy verified against Jagannatha Hora across 71
+    automated checks. Covers horoscope, kundali, dasha, panchang, matching,
+    Claude AI narratives, and 23 languages.
+  contact:
+    email: support@vedintelastroapi.com
+    url: https://vedintelastroapi.com
+  x-logo:
+    url: https://vedintelastroapi.com/logo-dark.png
+  x-apisguru-categories:
+    - science
+  x-origin:
+    - format: openapi
+      url: https://vedintelastroapi.com/api/openapi.json
+      version: '3.0'
+  x-providerName: vedintelastroapi.com
+servers:
+  - url: https://vedintelastroapi.com


### PR DESCRIPTION
New API submission: VedIntel™ AstroAPI

- Provider: vedintelastroapi.com
- Category: science
- 116 endpoints covering Vedic horoscope, kundali, dasha, panchang, 
  matching, AI narratives, tarot, and western astrology
- Built on Swiss Ephemeris (local computation, no third-party dependency)
- Accuracy verified against Jagannatha Hora — 71 automated daily checks
- OpenAPI spec available at: https://vedintelastroapi.com/api/openapi.json
- Free tier: 500 calls/month, no credit card required