### PR TITLE
Add OpenChainBench API

### DIFF
--- a/APIs/openchainbench.com/1.0.0/openapi.yaml
+++ b/APIs/openchainbench.com/1.0.0/openapi.yaml
@@ -96,8 +96,9 @@ components:
         unit:
           type: string
         value:
-          type: number
-          nullable: true
+          type:
+            - number
+            - "null"
         headline:
           type: string
         url:
@@ -120,12 +121,15 @@ components:
         title:
           type: string
         value:
-          type: number
-          nullable: true
+          type:
+            - number
+            - "null"
         unit:
           type: string
         rankings:
           type: array
+          items:
+            $ref: "#/components/schemas/Ranking"
         sparkline:
           type: array
           items:
@@ -140,3 +144,40 @@ components:
         asOf:
           type: string
           format: date-time
+    Ranking:
+      type: object
+      properties:
+        name:
+          type: string
+        slug:
+          type: string
+        ms:
+          type: object
+          properties:
+            p50:
+              type: number
+            p90:
+              type: number
+            p99:
+              type: number
+            mean:
+              type: number
+        successRate:
+          type: number
+        sampleSize:
+          type:
+            - integer
+            - "null"
+        sampleHealth:
+          type:
+            - number
+            - "null"
+        dataConfidence:
+          type:
+            - string
+            - "null"
+          enum:
+            - healthy
+            - low
+            - insufficient
+            - null

--- a/APIs/openchainbench.com/1.0.0/openapi.yaml
+++ b/APIs/openchainbench.com/1.0.0/openapi.yaml
@@ -1,0 +1,142 @@
+openapi: 3.1.0
+info:
+  contact:
+    email: contact@openchainbench.com
+    name: OpenChainBench
+    url: https://openchainbench.com
+  description: Open, reproducible benchmarks for crypto infrastructure including RPC providers, oracles, bridges, L1 finality, and prediction markets. Daily Parquet snapshots and a Zenodo DOI for citations.
+  license:
+    name: CC-BY-4.0
+    url: https://creativecommons.org/licenses/by/4.0/
+  title: OpenChainBench API
+  version: "1.0.0"
+  x-apisguru-categories:
+    - open_data
+    - analytics
+  x-logo:
+    url: https://openchainbench.com/logo.png
+  x-origin:
+    - format: openapi
+      url: https://openchainbench.com/api/openapi.json
+      version: "3.1"
+  x-providerName: openchainbench.com
+servers:
+  - url: https://openchainbench.com
+paths:
+  /api/citable:
+    get:
+      summary: Flat index of every citable benchmark with current values.
+      operationId: list_benchmarks
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CitableIndex"
+  /api/stat/{slug}:
+    get:
+      summary: Single benchmark with rankings, sparkline, and a ready-to-paste citation.
+      operationId: get_benchmark
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Benchmark slug (e.g. 'aggregator-head-lag').
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Stat"
+        "404":
+          description: Unknown slug
+  /api/og/{slug}:
+    get:
+      summary: Watermarked 1200x630 PNG showing the current value and sparkline.
+      operationId: get_og_image
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: PNG
+          content:
+            image/png: {}
+        "404":
+          description: Unknown slug
+components:
+  schemas:
+    CitableIndex:
+      type: object
+      properties:
+        site:
+          type: object
+        count:
+          type: integer
+        benchmarks:
+          type: array
+          items:
+            $ref: "#/components/schemas/CitableRow"
+    CitableRow:
+      type: object
+      properties:
+        slug:
+          type: string
+        title:
+          type: string
+        metric:
+          type: string
+        unit:
+          type: string
+        value:
+          type: number
+          nullable: true
+        headline:
+          type: string
+        url:
+          type: string
+          format: uri
+        api:
+          type: string
+          format: uri
+        ogImage:
+          type: string
+          format: uri
+        asOf:
+          type: string
+          format: date-time
+    Stat:
+      type: object
+      properties:
+        slug:
+          type: string
+        title:
+          type: string
+        value:
+          type: number
+          nullable: true
+        unit:
+          type: string
+        rankings:
+          type: array
+        sparkline:
+          type: array
+          items:
+            type: number
+        headline:
+          type: string
+        quote:
+          type: string
+        pageUrl:
+          type: string
+          format: uri
+        asOf:
+          type: string
+          format: date-time


### PR DESCRIPTION
## New API Submission

**API:** OpenChainBench
**Base URL:** https://openchainbench.com
**Docs:** https://openchainbench.com/api/openapi.json

### Description

OpenChainBench publishes daily open benchmarks for crypto infrastructure: RPC providers, oracles, bridges, L1 finality, prediction markets, and Hyperliquid builders. Data is reproducible, methodology is public, and citable Parquet snapshots are mirrored on HuggingFace with a Zenodo DOI.

Endpoints exposed:
- `/api/citable` — flat index of all benchmarks
- `/api/stat/{slug}` — single benchmark with rankings, sparkline, citation
- `/api/og/{slug}` — OG image for a benchmark

No authentication. CORS enabled (`access-control-allow-origin: *`).

### Maintainer

Mobula / OpenChainBench (contact@openchainbench.com)
Source and methodology: https://github.com/ChainBench/OpenChainBench