### PR TITLE
Add Revnuvo x402 paid domain intelligence APIs

### DIFF
--- a/APIs/revnuvo.site/assess/openapi.yaml
+++ b/APIs/revnuvo.site/assess/openapi.yaml
@@ -1,0 +1,104 @@
+openapi: 3.1.0
+info:
+  title: Revnuvo Assess API
+  description: Domain trust and risk assessment for AI agents and developers. x402
+    USDC payments on Base.
+  version: 4.1.0
+  x-guidance: "Use POST /assess/domain to assess a domain trust and security posture.\
+    \ Returns a letter grade (A-F), trust score (0-100), risk score, and recommendation\
+    \ (TRUSTED/REVIEW/RISKY). Requires x402 payment \u2014 send a POST with JSON body\
+    \ and handle the 402 challenge using the @revnuvo/x402 SDK or any x402-compatible\
+    \ client."
+  contact:
+    email: hello@revnuvo.site
+servers:
+- url: https://assess.revnuvo.site
+paths:
+  /assess/domain:
+    post:
+      operationId: assessDomain
+      summary: Assess a domain's trust and security posture
+      security:
+      - x402: []
+      x-payment-info:
+        price:
+          mode: fixed
+          currency: USD
+          amount: '0.050000'
+        protocols:
+        - x402: {}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - domain
+              properties:
+                domain:
+                  type: string
+                  examples:
+                  - example.com
+      responses:
+        '200':
+          description: Domain assessment result
+          headers:
+            PAYMENT-RESPONSE:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  domain:
+                    type: string
+                  trust_score:
+                    type: integer
+                    minimum: 0
+                    maximum: 100
+                  risk_score:
+                    type: integer
+                    minimum: 0
+                    maximum: 100
+                  grade:
+                    type: string
+                    enum:
+                    - A
+                    - B
+                    - C
+                    - D
+                    - F
+                  recommendation:
+                    type: string
+                    enum:
+                    - TRUSTED
+                    - REVIEW
+                    - RISKY
+                  risk_flags:
+                    type: array
+                    items:
+                      type: string
+                  signals:
+                    type: object
+                  assessed_at:
+                    type: string
+                    format: date-time
+        '400':
+          description: Invalid or missing domain
+        '402':
+          description: Payment required
+          headers:
+            WWW-Authenticate:
+              schema:
+                type: string
+                enum:
+                - x402
+components:
+  securitySchemes:
+    x402:
+      type: apiKey
+      in: header
+      name: PAYMENT-SIGNATURE
+      description: x402 v2 payment signature header

--- a/APIs/revnuvo.site/dns-intelligence/openapi.yaml
+++ b/APIs/revnuvo.site/dns-intelligence/openapi.yaml
@@ -1,0 +1,97 @@
+openapi: 3.0.0
+info:
+  title: Revnuvo DNS Intelligence API
+  version: 1.1.0
+  description: Instant domain intelligence for AI agents. No signup. x402 USDC payments
+    on Base.
+servers:
+- url: https://dns.revnuvo.site
+paths:
+  /domain/verify:
+    post:
+      summary: Verify domain registration status
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain:
+                  type: string
+                  description: Domain to verify e.g. stripe.com
+              required:
+              - domain
+      responses:
+        '200':
+          description: DNS verification result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  domain:
+                    type: string
+                  exists:
+                    type: boolean
+                  has_mx:
+                    type: boolean
+                  has_a:
+                    type: boolean
+                  dnssec:
+                    type: boolean
+                  checked_at:
+                    type: string
+                    format: date-time
+        '402':
+          description: Payment Required
+  /domain/dns:
+    post:
+      summary: Resolve DNS records for a domain
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain:
+                  type: string
+                  description: Domain to resolve e.g. stripe.com
+              required:
+              - domain
+      responses:
+        '200':
+          description: DNS records
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  domain:
+                    type: string
+                  a:
+                    type: array
+                    items:
+                      type: string
+                  aaaa:
+                    type: array
+                    items:
+                      type: string
+                  mx:
+                    type: array
+                    items:
+                      type: string
+                  txt:
+                    type: array
+                    items:
+                      type: string
+                  ns:
+                    type: array
+                    items:
+                      type: string
+                  resolved_at:
+                    type: string
+                    format: date-time
+        '402':
+          description: Payment Required

--- a/APIs/revnuvo.site/logo.svg
+++ b/APIs/revnuvo.site/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" rx="20" fill="#0B1426"/><text x="50" y="68" font-size="52" font-weight="bold" text-anchor="middle" fill="#06B6D4" font-family="sans-serif">R</text></svg>

--- a/APIs/revnuvo.site/resource/openapi.yaml
+++ b/APIs/revnuvo.site/resource/openapi.yaml
@@ -1,0 +1,231 @@
+openapi: 3.1.0
+info:
+  title: Revnuvo Resource API
+  description: Domain verification, DNS lookup, and trust assessment for AI agents
+    and developers. x402 USDC payments on Base.
+  version: 2.2.0
+  x-guidance: 'Use POST /domain/verify to check if a domain exists and has basic DNS
+    records. Use POST /domain/dns for full DNS record lookup (A, AAAA, MX, TXT, NS,
+    CNAME). Use POST /domain/assess for a trust and risk assessment with a letter
+    grade. All endpoints require x402 payment. For POST, send JSON body {"domain":
+    "example.com"}. For GET, add ?domain=example.com as a query parameter. Handle
+    the 402 challenge using the @revnuvo/x402 SDK or any x402-compatible client.'
+  contact:
+    email: hello@revnuvo.site
+servers:
+- url: https://resource.revnuvo.site
+paths:
+  /domain/verify:
+    post:
+      operationId: verifyDomain
+      summary: Verify a domain's existence and basic DNS records
+      security:
+      - x402: []
+      x-payment-info:
+        price:
+          mode: fixed
+          currency: USD
+          amount: '0.001000'
+        protocols:
+        - x402: {}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - domain
+              properties:
+                domain:
+                  type: string
+                  examples:
+                  - example.com
+      responses:
+        '200':
+          description: Domain verification result
+          headers:
+            PAYMENT-RESPONSE:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  domain:
+                    type: string
+                  exists:
+                    type: boolean
+                  has_a:
+                    type: boolean
+                  has_mx:
+                    type: boolean
+                  dnssec:
+                    type: boolean
+                  checked_at:
+                    type: string
+                    format: date-time
+        '400':
+          description: Invalid or missing domain
+        '402':
+          description: Payment required
+          headers:
+            WWW-Authenticate:
+              schema:
+                type: string
+                enum:
+                - x402
+  /domain/dns:
+    post:
+      operationId: dnsLookup
+      summary: Full DNS record lookup (A, AAAA, MX, TXT, NS, CNAME)
+      security:
+      - x402: []
+      x-payment-info:
+        price:
+          mode: fixed
+          currency: USD
+          amount: '0.002000'
+        protocols:
+        - x402: {}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - domain
+              properties:
+                domain:
+                  type: string
+                  examples:
+                  - example.com
+      responses:
+        '200':
+          description: DNS records
+          headers:
+            PAYMENT-RESPONSE:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  domain:
+                    type: string
+                  a:
+                    type: array
+                    items:
+                      type: string
+                  aaaa:
+                    type: array
+                    items:
+                      type: string
+                  mx:
+                    type: array
+                    items:
+                      type: string
+                  txt:
+                    type: array
+                    items:
+                      type: string
+                  ns:
+                    type: array
+                    items:
+                      type: string
+                  cname:
+                    type: array
+                    items:
+                      type: string
+                  resolved_at:
+                    type: string
+                    format: date-time
+        '400':
+          description: Invalid or missing domain
+        '402':
+          description: Payment required
+  /domain/assess:
+    post:
+      operationId: assessDomain
+      summary: Assess a domain's trust and security posture
+      security:
+      - x402: []
+      x-payment-info:
+        price:
+          mode: fixed
+          currency: USD
+          amount: '0.005000'
+        protocols:
+        - x402: {}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - domain
+              properties:
+                domain:
+                  type: string
+                  examples:
+                  - example.com
+      responses:
+        '200':
+          description: Domain assessment result
+          headers:
+            PAYMENT-RESPONSE:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  domain:
+                    type: string
+                  trust_score:
+                    type: integer
+                    minimum: 0
+                    maximum: 100
+                  risk_score:
+                    type: integer
+                    minimum: 0
+                    maximum: 100
+                  grade:
+                    type: string
+                    enum:
+                    - A
+                    - B
+                    - C
+                    - D
+                    - F
+                  recommendation:
+                    type: string
+                    enum:
+                    - TRUSTED
+                    - REVIEW
+                    - RISKY
+                  risk_flags:
+                    type: array
+                    items:
+                      type: string
+                  signals:
+                    type: object
+                  assessed_at:
+                    type: string
+                    format: date-time
+        '400':
+          description: Invalid or missing domain
+        '402':
+          description: Payment required
+components:
+  securitySchemes:
+    x402:
+      type: apiKey
+      in: header
+      name: PAYMENT-SIGNATURE
+      description: x402 v2 payment signature header


### PR DESCRIPTION
Adding 3 Revnuvo x402 v2 paid APIs under revnuvo.site/:

- **resource**: domain verification ($0.001), DNS lookup ($0.002), trust assessment ($0.005)
- **assess**: premium domain trust assessment ($0.05)
- **dns-intelligence**: domain verification, DNS lookup, trust assessment

All use x402 v2 protocol for per-request USDC payments on Base mainnet. No API keys — pay per call with crypto.

Proven with settled Basescan transactions:
- https://basescan.org/tx/0x606bb887307bbafc0cd16d546378ae4bc7f8f035f810f15323fb6e3c70d76773
- https://basescan.org/tx/0x0c263f26e0a289d38daa9fc064c8444a5e4e21e668404a01b3e830797a32b9a3
- https://basescan.org/tx/0x5901d53f017ea4ff7e1c9581c6f11bb6c48931803430779af3b0531417e9add5

Registered on x402scan. MCP server: https://github.com/hardeyhemy/revnuvo-mcp